### PR TITLE
chore: Bump version to 3.2.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "name": "fractary-faber",
         "source": "./plugins/faber",
         "description": "Universal SDLC workflow framework - Frame → Architect → Build → Evaluate → Release",
-        "version": "3.2.3",
+        "version": "3.2.4",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,13 +25,9 @@
     "fractary-codex@fractary-codex": true,
     "fractary-repo@fractary-core": true,
     "fractary-work@fractary-core": true,
-    "fractary-file@fractary-core": true,
     "fractary-docs@fractary-core": true,
-    "fractary-logs@fractary-core": true,
     "fractary-spec@fractary-core": true,
-    "fractary-status@fractary-core": true,
     "fractary-faber@fractary-faber": true,
-    "fractary-faber-cloud@fractary-faber": true
   },
   "permissions": {
     "bash": {

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Universal SDLC workflow framework with two-phase plan/execute architecture",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary
- Update fractary-faber plugin version from 3.2.3 to 3.2.4
- Remove unused plugins from settings configuration
- Update marketplace configuration

## Test plan
- [x] Verify version updated in marketplace.json
- [x] Verify version updated in plugin.json
- [x] Verify settings.json cleaned up of unused plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)