### PR TITLE
chore: Bump version to 3.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready workflow orchestration.",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-faber",
         "source": "./plugins/faber",
         "description": "Universal SDLC workflow framework - Frame → Architect → Build → Evaluate → Release",
-        "version": "3.2.4",
+        "version": "3.2.5",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Universal SDLC workflow framework with two-phase plan/execute architecture",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary
- Update marketplace version to 2.0.5
- Update fractary-faber plugin version to 3.2.5

## Test plan
- Version numbers are correctly updated in both configuration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)