### PR TITLE
chore: Bump fractary-faber plugin version to 3.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready workflow orchestration.",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-faber",
         "source": "./plugins/faber",
         "description": "Universal SDLC workflow framework - Frame → Architect → Build → Evaluate → Release",
-        "version": "3.2.7",
+        "version": "3.3.0",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.2.7",
+  "version": "3.3.0",
   "description": "Universal SDLC workflow framework with unified orchestrator pattern (plan + run)",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary

Bumps the fractary-faber plugin version to 3.3.0 to reflect the new context management features added in PR #34.

- Plugin version: 3.2.7 → 3.3.0 (minor version bump for new features)
- Marketplace version: 2.0.7 → 2.0.8

## Changes

- Updated `plugins/faber/.claude-plugin/plugin.json`
- Updated `.claude-plugin/marketplace.json`

## Features Now Available in 3.3.0

- `/fractary-faber:prime-context` command for manual context reloading
- `/fractary-faber:session-end` command for session cleanup
- Automatic context reload on session start
- Cross-environment workflow portability with path templates
- Session tracking in workflow state

🤖 Generated with [Claude Code](https://claude.com/claude-code)