### PR TITLE
docs: Fix workflow orchestration protocol for correct command execution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "name": "fractary-faber",
         "source": "./plugins/faber",
         "description": "Universal SDLC workflow framework - Frame → Architect → Build → Evaluate → Release",
-        "version": "3.4.0",
+        "version": "3.4.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Universal SDLC workflow framework with unified orchestrator pattern (plan + run)",
   "commands": "./commands/",
   "agents": [


### PR DESCRIPTION
## Summary

The workflow orchestration protocol documentation contained incorrect guidance for executing workflow step prompts. It instructed orchestrators to parse and manipulate slash commands, which doesn't match actual workflow definitions or command implementations.

## Changes

### Fixed command execution guidance
- EXECUTE Step section now correctly passes full command string to Skill tool
- Example: `/fractary-spec:create --work-id {work_id}` passed as-is, not parsed

### Added clarifications to Core Principles
- Slash commands are complete, self-contained invocations
- Commands handle their own argument parsing and execution strategy
- Orchestrator must not parse or manipulate command strings
- Trust commands to handle their own logic

### New "Command Execution Patterns" section
- **Pattern 1: Agent-delegating commands** - delegate to specialized agents via Task tool
- **Pattern 2: Inline commands** - execute directly using bash, Read, Write, etc.
- Explains why orchestrator doesn't need to distinguish between patterns

### Version bump
- Plugin version bumped from 3.4.0 to 3.4.1

## Test plan
- [x] Workflow definitions verified to use complete command strings
- [x] Changes match actual command implementations
- [x] Documentation is clear about two execution patterns
- [x] Both manifest files updated with version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)