### PR TITLE
fix: ES modules compatibility - add .js extensions and bump versions to 2.1.1/1.3.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fractary/core": "^0.2.0",
-    "@fractary/faber": "*",
+    "@fractary/faber": "^2.1.1",
     "chalk": "^5.0.0",
     "commander": "^12.0.0"
   },

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -84,7 +84,7 @@ logs/session-*.md
  */
 function createDefaultConfig(preset: string): object {
   const baseConfig = {
-    version: '1.0.0',
+    version: '1.3.1',
     preset,
 
     // Work tracking configuration

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,7 +17,7 @@ import { createLogsCommand } from './commands/logs/index.js';
 import { createInitCommand } from './commands/init.js';
 import { createPlanCommand } from './commands/plan/index.js';
 
-const version = '1.0.0';
+const version = '1.3.1';
 
 /**
  * Create and configure the main CLI program

--- a/cli/src/lib/anthropic-client.ts
+++ b/cli/src/lib/anthropic-client.ts
@@ -149,7 +149,7 @@ export class AnthropicClient {
       ...planJson,
       plan_id: planId,
       created_by: 'cli',
-      cli_version: '1.0.0',
+      cli_version: '1.3.1',
       created_at: new Date().toISOString(),
       issue: {
         source: 'github',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,16 @@
         "cli",
         "mcp/server"
       ],
+      "dependencies": {
+        "@fractary/forge": "^1.1.4"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "cli": {
       "name": "@fractary/faber-cli",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@fractary/core": "^0.2.0",
@@ -1209,6 +1212,20 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fractary/codex": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fractary/codex/-/codex-0.1.3.tgz",
+      "integrity": "sha512-nFscfgiLGsMwEeX6qDMymnybJIk4nWoOKC5aurLtw0I9OgpDWwdUeTtM7fU/VUTfMXmsigVTI+Bvm24/hf/9jA==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "micromatch": "^4.0.8",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@fractary/core": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@fractary/core/-/core-0.2.0.tgz",
@@ -1236,11 +1253,13 @@
       "link": true
     },
     "node_modules/@fractary/forge": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@fractary/forge/-/forge-1.1.1.tgz",
-      "integrity": "sha512-n11ryZDFYjkPjc1rUEPt1Znmi3NAwKG3rDehkWCX6HdMfuRNOwyfMqDQSQ1VWnOAoP1z6af/X6iOkCjthKvwmg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@fractary/forge/-/forge-1.1.4.tgz",
+      "integrity": "sha512-HHDnttN/Gpt99TnFiyxeco0xkK+0gKjow+/fWH99cBHxe5eVPA0TkAuSec9csKe4z79YUjKRloFsiAwVk203gQ==",
       "license": "MIT",
       "dependencies": {
+        "@fractary/codex": "^0.1.3",
+        "@fractary/faber": "^1.2.0",
         "@langchain/anthropic": "^0.3.0",
         "@langchain/core": "^0.3.0",
         "@langchain/google-genai": "^0.1.0",
@@ -1250,11 +1269,30 @@
         "follow-redirects": "^1.15.5",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.0",
+        "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "minimatch": "^10.0.3",
         "ora": "^5.4.1",
         "semver": "^7.5.4",
         "zod": "^3.22.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fractary/forge/node_modules/@fractary/faber": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@fractary/faber/-/faber-1.2.2.tgz",
+      "integrity": "sha512-6q+5W8l7pj2+Lg3aZXes+fmP0bNecYgUhMgoLV8dU38mvKsbz/aTGb1kMndh0ntiVZnM4a+KT25NAejhjGxKDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fractary/forge": "^1.1.1",
+        "commander": "^12.0.0",
+        "js-yaml": "^4.1.1",
+        "zod": "^3.22.4"
+      },
+      "bin": {
+        "fractary": "dist/cli/index.js"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3680,7 +3718,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4762,7 +4799,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5013,6 +5049,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5134,7 +5182,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5550,6 +5597,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -5817,6 +5901,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5872,7 +5965,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6815,6 +6907,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -7066,7 +7167,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7680,7 +7780,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8300,6 +8399,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -8558,7 +8670,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -8728,6 +8839,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -8916,7 +9036,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10352,7 +10471,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@fractary/forge": "^1.1.1",
+        "@fractary/forge": "^1.1.4",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
         "zod": "^3.22.4"

--- a/package.json
+++ b/package.json
@@ -12,21 +12,17 @@
     "build": "npm run build:js && npm run build:py",
     "test": "npm run test:js && npm run test:py",
     "lint": "npm run lint:js && npm run lint:py",
-
     "build:js": "npm run build -w sdk/js",
     "test:js": "npm run test -w sdk/js",
     "lint:js": "npm run lint -w sdk/js",
     "typecheck:js": "npm run typecheck -w sdk/js",
-
     "build:cli": "npm run build -w cli",
     "test:cli": "npm run test -w cli",
     "lint:cli": "npm run lint -w cli",
     "typecheck:cli": "npm run typecheck -w cli",
-
     "build:py": "cd sdk/py && python -m build",
     "test:py": "cd sdk/py && pytest",
     "lint:py": "cd sdk/py && ruff check .",
-
     "install:py": "cd sdk/py && pip install -e '.[dev]'",
     "clean": "npm run clean:js && npm run clean:py",
     "clean:js": "rm -rf sdk/js/dist sdk/js/node_modules",
@@ -44,5 +40,8 @@
   },
   "homepage": "https://github.com/fractary/faber#readme",
   "author": "Fractary Team",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@fractary/forge": "^1.1.4"
+  }
 }

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "FABER SDK - Development toolkit for AI-assisted workflows",
   "type": "module",
   "main": "dist/index.js",
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@fractary/forge": "^1.1.1",
+    "@fractary/forge": "^1.1.4",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1",
     "zod": "^3.22.4"

--- a/sdk/js/src/__tests__/config.test.ts
+++ b/sdk/js/src/__tests__/config.test.ts
@@ -13,9 +13,9 @@ import {
   loadSpecConfig,
   loadLogConfig,
   loadStateConfig,
-} from '../config';
-import { ConfigInitializer } from '../config/initializer';
-import { ConfigValidationError } from '../errors';
+} from '../config.js';
+import { ConfigInitializer } from '../config/initializer.js';
+import { ConfigValidationError } from '../errors.js';
 
 describe('Config Loading Functions', () => {
   const testDir = path.join(__dirname, '__test-config-loading__');

--- a/sdk/js/src/__tests__/integration/forge-integration.test.ts
+++ b/sdk/js/src/__tests__/integration/forge-integration.test.ts
@@ -4,8 +4,8 @@
  * Integration tests for FABER + Forge workflow execution
  */
 
-import { FaberWorkflow } from '../../workflow/faber';
-import { AgentExecutor } from '../../workflow/agent-executor';
+import { FaberWorkflow } from '../../workflow/faber.js';
+import { AgentExecutor } from '../../workflow/agent-executor.js';
 
 // Mock @fractary/forge
 jest.mock('@fractary/forge', () => ({

--- a/sdk/js/src/__tests__/integration/init-workflow.test.ts
+++ b/sdk/js/src/__tests__/integration/init-workflow.test.ts
@@ -6,14 +6,14 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { ConfigInitializer } from '../../config/initializer';
+import { ConfigInitializer } from '../../config/initializer.js';
 import {
   loadFaberConfig,
   loadWorkConfig,
   loadRepoConfig,
   loadSpecConfig,
-} from '../../config';
-import { SpecManager } from '../../spec/manager';
+} from '../../config.js';
+import { SpecManager } from '../../spec/manager.js';
 
 describe('Init Workflow Integration', () => {
   const testDir = path.join(__dirname, '__test-init-workflow__');

--- a/sdk/js/src/config.ts
+++ b/sdk/js/src/config.ts
@@ -16,8 +16,8 @@ import {
   SpecConfig,
   LogConfig,
   StateConfig,
-} from './types';
-import { ConfigValidationError } from './errors';
+} from './types.js';
+import { ConfigValidationError } from './errors.js';
 
 // ============================================================================
 // Configuration Loading Options
@@ -662,7 +662,7 @@ export function loadStateConfig(projectRoot?: string): StateConfig {
 // Exports
 // ============================================================================
 
-export { ConfigInitializer } from './config/initializer';
+export { ConfigInitializer } from './config/initializer.js';
 
 export {
   FaberConfigSchema,

--- a/sdk/js/src/config/__tests__/initializer.test.ts
+++ b/sdk/js/src/config/__tests__/initializer.test.ts
@@ -7,8 +7,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
-import { ConfigInitializer } from '../initializer';
-import { FaberConfig } from '../../types';
+import { ConfigInitializer } from '../initializer.js';
+import { FaberConfig } from '../../types.js';
 
 describe('ConfigInitializer', () => {
   const testDir = path.join(__dirname, '__test-configs__');

--- a/sdk/js/src/config/initializer.ts
+++ b/sdk/js/src/config/initializer.ts
@@ -8,7 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
-import { FaberConfig } from '../types';
+import { FaberConfig } from '../types.js';
 
 /**
  * ConfigInitializer class for generating and managing FABER configuration

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -14,15 +14,15 @@
  */
 
 // Core exports
-export * from './types';
-export * from './errors';
-export * from './config';
+export * from './types.js';
+export * from './errors.js';
+export * from './config.js';
 
 // Module exports
-export * from './work';
-export * from './repo';
-export * from './spec';
-export * from './logs';
-export * from './state';
-export * from './workflow';
-export * from './storage';
+export * from './work/index.js';
+export * from './repo/index.js';
+export * from './spec/index.js';
+export * from './logs/index.js';
+export * from './state/index.js';
+export * from './workflow/index.js';
+export * from './storage/index.js';

--- a/sdk/js/src/logs/index.ts
+++ b/sdk/js/src/logs/index.ts
@@ -4,5 +4,5 @@
  * Session and operational logging.
  */
 
-export { LogManager } from './manager';
-export * from './types';
+export { LogManager } from './manager.js';
+export * from './types.js';

--- a/sdk/js/src/logs/manager.ts
+++ b/sdk/js/src/logs/manager.ts
@@ -20,9 +20,9 @@ import {
   CaptureSession,
   LogAppendOptions,
   ArchiveResult,
-} from './types';
-import { loadLogConfig, findProjectRoot } from '../config';
-import { LogError } from '../errors';
+} from './types.js';
+import { loadLogConfig, findProjectRoot } from '../config.js';
+import { LogError } from '../errors.js';
 
 /**
  * Generate a unique log ID

--- a/sdk/js/src/logs/types.ts
+++ b/sdk/js/src/logs/types.ts
@@ -18,7 +18,7 @@ export {
   SessionState,
   CaptureStartOptions,
   CaptureResult,
-} from '../types';
+} from '../types.js';
 
 /**
  * Session capture state stored in state module

--- a/sdk/js/src/repo/git.ts
+++ b/sdk/js/src/repo/git.ts
@@ -12,11 +12,11 @@ import {
   Branch,
   Tag,
   Worktree,
-} from '../types';
+} from '../types.js';
 import {
   CommandExecutionError,
-} from '../errors';
-import { findProjectRoot } from '../config';
+} from '../errors.js';
+import { findProjectRoot } from '../config.js';
 
 /**
  * Execute a git command

--- a/sdk/js/src/repo/index.ts
+++ b/sdk/js/src/repo/index.ts
@@ -4,7 +4,7 @@
  * Repository operations across GitHub, GitLab, and Bitbucket.
  */
 
-export { RepoManager } from './manager';
-export { Git } from './git';
-export * from './types';
-export * from './providers';
+export { RepoManager } from './manager.js';
+export { Git } from './git.js';
+export * from './types.js';
+export * from './providers/index.js';

--- a/sdk/js/src/repo/manager.ts
+++ b/sdk/js/src/repo/manager.ts
@@ -28,14 +28,14 @@ import {
   WorktreeCleanupOptions,
   PushOptions,
   PullOptions,
-} from '../types';
-import { RepoProvider, WorktreeCleanupResult, DiffOptions } from './types';
-import { Git } from './git';
-import { GitHubRepoProvider } from './providers/github';
-import { GitLabRepoProvider } from './providers/gitlab';
-import { BitbucketRepoProvider } from './providers/bitbucket';
-import { loadRepoConfig } from '../config';
-import { ConfigurationError, BranchExistsError, ProtectedBranchError } from '../errors';
+} from '../types.js';
+import { RepoProvider, WorktreeCleanupResult, DiffOptions } from './types.js';
+import { Git } from './git.js';
+import { GitHubRepoProvider } from './providers/github.js';
+import { GitLabRepoProvider } from './providers/gitlab.js';
+import { BitbucketRepoProvider } from './providers/bitbucket.js';
+import { loadRepoConfig } from '../config.js';
+import { ConfigurationError, BranchExistsError, ProtectedBranchError } from '../errors.js';
 
 /**
  * Create a provider based on platform

--- a/sdk/js/src/repo/providers/bitbucket.ts
+++ b/sdk/js/src/repo/providers/bitbucket.ts
@@ -16,9 +16,9 @@ import {
   BranchCreateOptions,
   BranchDeleteOptions,
   BranchListOptions,
-} from '../../types';
-import { RepoProvider } from '../types';
-import { ProviderError } from '../../errors';
+} from '../../types.js';
+import { RepoProvider } from '../types.js';
+import { ProviderError } from '../../errors.js';
 
 /**
  * Bitbucket repository provider

--- a/sdk/js/src/repo/providers/github.ts
+++ b/sdk/js/src/repo/providers/github.ts
@@ -16,10 +16,10 @@ import {
   BranchCreateOptions,
   BranchDeleteOptions,
   BranchListOptions,
-} from '../../types';
-import { RepoProvider } from '../types';
-import { ProviderError } from '../../errors';
-import { findProjectRoot } from '../../config';
+} from '../../types.js';
+import { RepoProvider } from '../types.js';
+import { ProviderError } from '../../errors.js';
+import { findProjectRoot } from '../../config.js';
 
 /**
  * Execute a gh command and return JSON result

--- a/sdk/js/src/repo/providers/gitlab.ts
+++ b/sdk/js/src/repo/providers/gitlab.ts
@@ -16,9 +16,9 @@ import {
   BranchCreateOptions,
   BranchDeleteOptions,
   BranchListOptions,
-} from '../../types';
-import { RepoProvider } from '../types';
-import { ProviderError } from '../../errors';
+} from '../../types.js';
+import { RepoProvider } from '../types.js';
+import { ProviderError } from '../../errors.js';
 
 /**
  * GitLab repository provider

--- a/sdk/js/src/repo/providers/index.ts
+++ b/sdk/js/src/repo/providers/index.ts
@@ -4,6 +4,6 @@
  * Repository provider exports.
  */
 
-export { GitHubRepoProvider } from './github';
-export { GitLabRepoProvider } from './gitlab';
-export { BitbucketRepoProvider } from './bitbucket';
+export { GitHubRepoProvider } from './github.js';
+export { GitLabRepoProvider } from './gitlab.js';
+export { BitbucketRepoProvider } from './bitbucket.js';

--- a/sdk/js/src/repo/types.ts
+++ b/sdk/js/src/repo/types.ts
@@ -33,7 +33,7 @@ export {
   WorktreeCleanupOptions,
   PushOptions,
   PullOptions,
-} from '../types';
+} from '../types.js';
 
 /**
  * Interface for repository providers
@@ -42,17 +42,17 @@ export interface RepoProvider {
   readonly platform: 'github' | 'gitlab' | 'bitbucket';
 
   // Branches
-  createBranch(name: string, options?: import('../types').BranchCreateOptions): Promise<import('../types').Branch>;
-  deleteBranch(name: string, options?: import('../types').BranchDeleteOptions): Promise<void>;
-  listBranches(options?: import('../types').BranchListOptions): Promise<import('../types').Branch[]>;
-  getBranch(name: string): Promise<import('../types').Branch | null>;
+  createBranch(name: string, options?: import('../types.js').BranchCreateOptions): Promise<import('../types.js').Branch>;
+  deleteBranch(name: string, options?: import('../types.js').BranchDeleteOptions): Promise<void>;
+  listBranches(options?: import('../types.js').BranchListOptions): Promise<import('../types.js').Branch[]>;
+  getBranch(name: string): Promise<import('../types.js').Branch | null>;
 
   // Pull Requests
-  createPR(options: import('../types').PRCreateOptions): Promise<import('../types').PullRequest>;
-  getPR(number: number): Promise<import('../types').PullRequest>;
-  updatePR(number: number, options: import('../types').PRUpdateOptions): Promise<import('../types').PullRequest>;
-  listPRs(options?: import('../types').PRListOptions): Promise<import('../types').PullRequest[]>;
-  mergePR(number: number, options?: import('../types').PRMergeOptions): Promise<import('../types').PullRequest>;
+  createPR(options: import('../types.js').PRCreateOptions): Promise<import('../types.js').PullRequest>;
+  getPR(number: number): Promise<import('../types.js').PullRequest>;
+  updatePR(number: number, options: import('../types.js').PRUpdateOptions): Promise<import('../types.js').PullRequest>;
+  listPRs(options?: import('../types.js').PRListOptions): Promise<import('../types.js').PullRequest[]>;
+  mergePR(number: number, options?: import('../types.js').PRMergeOptions): Promise<import('../types.js').PullRequest>;
   addPRComment(number: number, body: string): Promise<void>;
   requestReview(number: number, reviewers: string[]): Promise<void>;
   approvePR(number: number, comment?: string): Promise<void>;

--- a/sdk/js/src/spec/__tests__/manager.test.ts
+++ b/sdk/js/src/spec/__tests__/manager.test.ts
@@ -6,8 +6,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { SpecManager } from '../manager';
-import { ConfigInitializer } from '../../config/initializer';
+import { SpecManager } from '../manager.js';
+import { ConfigInitializer } from '../../config/initializer.js';
 
 describe('SpecManager', () => {
   const testDir = path.join(__dirname, '__test-spec-manager__');

--- a/sdk/js/src/spec/index.ts
+++ b/sdk/js/src/spec/index.ts
@@ -4,6 +4,6 @@
  * Specification management for FABER workflows.
  */
 
-export { SpecManager } from './manager';
-export * from './types';
-export { getTemplate, listTemplates, templates } from './templates';
+export { SpecManager } from './manager.js';
+export * from './types.js';
+export { getTemplate, listTemplates, templates } from './templates.js';

--- a/sdk/js/src/spec/manager.ts
+++ b/sdk/js/src/spec/manager.ts
@@ -19,10 +19,10 @@ import {
   SpecTemplateType,
   WorkType,
   PhaseUpdateOptions,
-} from './types';
-import { getTemplate, generateSpecContent, templates } from './templates';
-import { loadSpecConfig, findProjectRoot } from '../config';
-import { SpecError } from '../errors';
+} from './types.js';
+import { getTemplate, generateSpecContent, templates } from './templates.js';
+import { loadSpecConfig, findProjectRoot } from '../config.js';
+import { SpecError } from '../errors.js';
 
 /**
  * Parse spec frontmatter and content

--- a/sdk/js/src/spec/templates.ts
+++ b/sdk/js/src/spec/templates.ts
@@ -4,7 +4,7 @@
  * Built-in specification templates for different work types.
  */
 
-import { SpecTemplate, SpecTemplateType } from './types';
+import { SpecTemplate, SpecTemplateType } from './types.js';
 
 /**
  * Basic template - minimal structure for simple tasks

--- a/sdk/js/src/spec/types.ts
+++ b/sdk/js/src/spec/types.ts
@@ -5,7 +5,7 @@
  */
 
 // Import types
-import type { SpecTemplateType } from '../types';
+import type { SpecTemplateType } from '../types.js';
 
 // Re-export common types
 export type {
@@ -21,7 +21,7 @@ export type {
   SpecRefineResult,
   RefinementQuestion,
   WorkType,
-} from '../types';
+} from '../types.js';
 
 /**
  * Template definition

--- a/sdk/js/src/state/index.ts
+++ b/sdk/js/src/state/index.ts
@@ -4,5 +4,5 @@
  * Workflow state persistence and recovery.
  */
 
-export { StateManager } from './manager';
-export * from './types';
+export { StateManager } from './manager.js';
+export * from './types.js';

--- a/sdk/js/src/state/manager.ts
+++ b/sdk/js/src/state/manager.ts
@@ -18,9 +18,9 @@ import {
   StateUpdateOptions,
   StateQueryOptions,
   RecoveryOptions,
-} from './types';
-import { loadStateConfig, findProjectRoot } from '../config';
-import { StateError } from '../errors';
+} from './types.js';
+import { loadStateConfig, findProjectRoot } from '../config.js';
+import { StateError } from '../errors.js';
 
 /**
  * Generate a unique workflow ID

--- a/sdk/js/src/state/types.ts
+++ b/sdk/js/src/state/types.ts
@@ -14,7 +14,7 @@ export {
   PhaseManifest,
   StepManifest,
   ArtifactManifest,
-} from '../types';
+} from '../types.js';
 
 /**
  * State store key

--- a/sdk/js/src/storage/codex-adapter.ts
+++ b/sdk/js/src/storage/codex-adapter.ts
@@ -5,10 +5,10 @@
  * Uses runtime detection - no compile-time dependency on Codex.
  */
 
-import { Storage, FaberConfig } from '../types';
-import { FaberError } from '../errors';
-import { LocalStorage } from './local';
-import { findProjectRoot } from '../config';
+import { Storage, FaberConfig } from '../types.js';
+import { FaberError } from '../errors.js';
+import { LocalStorage } from './local.js';
+import { findProjectRoot } from '../config.js';
 
 // Type definitions for Codex (runtime detection)
 // These match the actual @fractary/codex API
@@ -94,7 +94,6 @@ export class CodexAdapter {
 
     try {
       // Dynamic import for ESM compatibility - no compile-time dependency
-      // @ts-expect-error - @fractary/codex is optional and may not be installed
       const codexModule = await import('@fractary/codex') as unknown as CodexModule;
       this.codex = codexModule;
       return codexModule;

--- a/sdk/js/src/storage/index.ts
+++ b/sdk/js/src/storage/index.ts
@@ -5,5 +5,5 @@
  * When @fractary/codex is installed and enabled, delegates to Codex.
  */
 
-export { LocalStorage } from './local';
-export { CodexAdapter, createStorage } from './codex-adapter';
+export { LocalStorage } from './local.js';
+export { CodexAdapter, createStorage } from './codex-adapter.js';

--- a/sdk/js/src/storage/local.ts
+++ b/sdk/js/src/storage/local.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { Storage } from '../types';
+import { Storage } from '../types.js';
 
 /**
  * Local filesystem storage implementation

--- a/sdk/js/src/work/index.ts
+++ b/sdk/js/src/work/index.ts
@@ -4,5 +4,5 @@
  * Work tracking across GitHub Issues, Jira, and Linear.
  */
 
-export { WorkManager } from './manager';
-export * from './types';
+export { WorkManager } from './manager.js';
+export * from './types.js';

--- a/sdk/js/src/work/manager.ts
+++ b/sdk/js/src/work/manager.ts
@@ -17,13 +17,13 @@ import {
   Milestone,
   MilestoneCreateOptions,
   FaberContext,
-} from '../types';
-import { WorkProvider, ListCommentsOptions } from './types';
-import { loadWorkConfig, findProjectRoot } from '../config';
-import { ConfigurationError } from '../errors';
-import { GitHubWorkProvider } from './providers/github';
-import { JiraWorkProvider } from './providers/jira';
-import { LinearWorkProvider } from './providers/linear';
+} from '../types.js';
+import { WorkProvider, ListCommentsOptions } from './types.js';
+import { loadWorkConfig, findProjectRoot } from '../config.js';
+import { ConfigurationError } from '../errors.js';
+import { GitHubWorkProvider } from './providers/github.js';
+import { JiraWorkProvider } from './providers/jira.js';
+import { LinearWorkProvider } from './providers/linear.js';
 
 /**
  * WorkManager - Unified work tracking across platforms

--- a/sdk/js/src/work/providers/github.ts
+++ b/sdk/js/src/work/providers/github.ts
@@ -16,15 +16,15 @@ import {
   Milestone,
   MilestoneCreateOptions,
   FaberContext,
-} from '../../types';
-import { WorkProvider } from '../types';
+} from '../../types.js';
+import { WorkProvider } from '../types.js';
 import {
   IssueNotFoundError,
   IssueCreateError,
   AuthenticationError,
   CommandExecutionError,
   ProviderError,
-} from '../../errors';
+} from '../../errors.js';
 
 /**
  * Execute a command and return the output

--- a/sdk/js/src/work/providers/jira.ts
+++ b/sdk/js/src/work/providers/jira.ts
@@ -16,9 +16,9 @@ import {
   Milestone,
   MilestoneCreateOptions,
   FaberContext,
-} from '../../types';
-import { WorkProvider } from '../types';
-import { ProviderError } from '../../errors';
+} from '../../types.js';
+import { WorkProvider } from '../types.js';
+import { ProviderError } from '../../errors.js';
 
 /**
  * Jira Issues provider

--- a/sdk/js/src/work/providers/linear.ts
+++ b/sdk/js/src/work/providers/linear.ts
@@ -16,9 +16,9 @@ import {
   Milestone,
   MilestoneCreateOptions,
   FaberContext,
-} from '../../types';
-import { WorkProvider } from '../types';
-import { ProviderError } from '../../errors';
+} from '../../types.js';
+import { WorkProvider } from '../types.js';
+import { ProviderError } from '../../errors.js';
 
 /**
  * Linear Issues provider

--- a/sdk/js/src/work/types.ts
+++ b/sdk/js/src/work/types.ts
@@ -19,7 +19,7 @@ export {
   Comment,
   CommentCreateOptions,
   FaberContext,
-} from '../types';
+} from '../types.js';
 
 /**
  * Interface for work tracking providers
@@ -28,48 +28,48 @@ export interface WorkProvider {
   readonly platform: 'github' | 'jira' | 'linear';
 
   // Issues
-  createIssue(options: import('../types').IssueCreateOptions): Promise<import('../types').Issue>;
-  fetchIssue(issueId: string | number): Promise<import('../types').Issue>;
+  createIssue(options: import('../types.js').IssueCreateOptions): Promise<import('../types.js').Issue>;
+  fetchIssue(issueId: string | number): Promise<import('../types.js').Issue>;
   updateIssue(
     issueId: string | number,
-    options: import('../types').IssueUpdateOptions
-  ): Promise<import('../types').Issue>;
-  closeIssue(issueId: string | number): Promise<import('../types').Issue>;
-  reopenIssue(issueId: string | number): Promise<import('../types').Issue>;
+    options: import('../types.js').IssueUpdateOptions
+  ): Promise<import('../types.js').Issue>;
+  closeIssue(issueId: string | number): Promise<import('../types.js').Issue>;
+  reopenIssue(issueId: string | number): Promise<import('../types.js').Issue>;
   searchIssues(
     query: string,
-    filters?: import('../types').IssueFilters
-  ): Promise<import('../types').Issue[]>;
+    filters?: import('../types.js').IssueFilters
+  ): Promise<import('../types.js').Issue[]>;
   assignIssue(
     issueId: string | number,
     assignee: string
-  ): Promise<import('../types').Issue>;
-  unassignIssue(issueId: string | number): Promise<import('../types').Issue>;
+  ): Promise<import('../types.js').Issue>;
+  unassignIssue(issueId: string | number): Promise<import('../types.js').Issue>;
 
   // Comments
   createComment(
     issueId: string | number,
     body: string,
-    faberContext?: import('../types').FaberContext
-  ): Promise<import('../types').Comment>;
+    faberContext?: import('../types.js').FaberContext
+  ): Promise<import('../types.js').Comment>;
   listComments(
     issueId: string | number,
     options?: { limit?: number; since?: string }
-  ): Promise<import('../types').Comment[]>;
+  ): Promise<import('../types.js').Comment[]>;
 
   // Labels
-  addLabels(issueId: string | number, labels: string[]): Promise<import('../types').Label[]>;
+  addLabels(issueId: string | number, labels: string[]): Promise<import('../types.js').Label[]>;
   removeLabels(issueId: string | number, labels: string[]): Promise<void>;
-  setLabels(issueId: string | number, labels: string[]): Promise<import('../types').Label[]>;
-  listLabels(issueId?: string | number): Promise<import('../types').Label[]>;
+  setLabels(issueId: string | number, labels: string[]): Promise<import('../types.js').Label[]>;
+  listLabels(issueId?: string | number): Promise<import('../types.js').Label[]>;
 
   // Milestones
   createMilestone(
-    options: import('../types').MilestoneCreateOptions
-  ): Promise<import('../types').Milestone>;
-  setMilestone(issueId: string | number, milestone: string): Promise<import('../types').Issue>;
-  removeMilestone(issueId: string | number): Promise<import('../types').Issue>;
-  listMilestones(state?: 'open' | 'closed' | 'all'): Promise<import('../types').Milestone[]>;
+    options: import('../types.js').MilestoneCreateOptions
+  ): Promise<import('../types.js').Milestone>;
+  setMilestone(issueId: string | number, milestone: string): Promise<import('../types.js').Issue>;
+  removeMilestone(issueId: string | number): Promise<import('../types.js').Issue>;
+  listMilestones(state?: 'open' | 'closed' | 'all'): Promise<import('../types.js').Milestone[]>;
 }
 
 /**

--- a/sdk/js/src/workflow/__tests__/agent-executor.test.ts
+++ b/sdk/js/src/workflow/__tests__/agent-executor.test.ts
@@ -2,9 +2,9 @@
  * @fractary/faber - AgentExecutor Tests
  */
 
-import { AgentExecutor } from '../agent-executor';
-import type { PhaseContext } from '../types';
-import { WorkflowError } from '../../errors';
+import { AgentExecutor } from '../agent-executor.js';
+import type { PhaseContext } from '../types.js';
+import { WorkflowError } from '../../errors.js';
 
 // Mock @fractary/forge
 jest.mock('@fractary/forge', () => ({

--- a/sdk/js/src/workflow/agent-executor.ts
+++ b/sdk/js/src/workflow/agent-executor.ts
@@ -5,8 +5,8 @@
  */
 
 import { AgentAPI, ExecutableAgentInterface, AgentResult } from '@fractary/forge';
-import { PhaseContext } from './types';
-import { WorkflowError } from '../errors';
+import { PhaseContext } from './types.js';
+import { WorkflowError } from '../errors.js';
 
 export interface ForgeConfig {
   enabled: boolean;
@@ -102,7 +102,7 @@ export class AgentExecutor {
 
       if (!agent) {
         // Resolve agent from Forge
-        agent = await this.forge!.resolveAgent(agentName);
+        agent = await this.forge!.agentResolve(agentName);
         this.agentCache.set(agentName, agent);
       }
 
@@ -174,7 +174,7 @@ export class AgentExecutor {
     for (const phase of phases) {
       const agentName = PHASE_AGENT_MAP[phase];
       try {
-        const check = await this.forge!.healthCheck(agentName);
+        const check = await this.forge!.agentHealthCheck(agentName);
         results[phase] = { healthy: check.healthy };
         if (!check.healthy) allHealthy = false;
       } catch (error) {

--- a/sdk/js/src/workflow/faber.ts
+++ b/sdk/js/src/workflow/faber.ts
@@ -17,14 +17,14 @@ import {
   WorkflowEvent,
   EventListener,
   ArtifactManifest,
-} from './types';
-import { WorkManager } from '../work';
-import { RepoManager } from '../repo';
-import { SpecManager } from '../spec';
-import { LogManager } from '../logs';
-import { StateManager } from '../state';
-import { WorkflowError } from '../errors';
-import { AgentExecutor } from './agent-executor';
+} from './types.js';
+import { WorkManager } from '../work/index.js';
+import { RepoManager } from '../repo/index.js';
+import { SpecManager } from '../spec/index.js';
+import { LogManager } from '../logs/index.js';
+import { StateManager } from '../state/index.js';
+import { WorkflowError } from '../errors.js';
+import { AgentExecutor } from './agent-executor.js';
 import type { AgentResult } from '@fractary/forge';
 
 /**

--- a/sdk/js/src/workflow/index.ts
+++ b/sdk/js/src/workflow/index.ts
@@ -4,7 +4,7 @@
  * FABER workflow orchestration.
  */
 
-export { FaberWorkflow } from './faber';
-export { AgentExecutor } from './agent-executor';
-export type { AgentExecutorConfig, ForgeConfig } from './agent-executor';
-export * from './types';
+export { FaberWorkflow } from './faber.js';
+export { AgentExecutor } from './agent-executor.js';
+export type { AgentExecutorConfig, ForgeConfig } from './agent-executor.js';
+export * from './types.js';

--- a/sdk/js/src/workflow/types.ts
+++ b/sdk/js/src/workflow/types.ts
@@ -15,7 +15,7 @@ export {
   WorkflowStatus,
   FaberPhase,
   ArtifactManifest,
-} from '../types';
+} from '../types.js';
 
 /**
  * Phase handler function type
@@ -30,8 +30,8 @@ export interface PhaseContext {
   workId: string;
   phase: string;
   autonomy: string;
-  issue: import('../types').Issue | null;
-  spec: import('../types').Specification | null;
+  issue: import('../types.js').Issue | null;
+  spec: import('../types.js').Specification | null;
   branch: string | null;
   previousOutputs: Record<string, Record<string, unknown>>;
 }

--- a/sdk/js/tsconfig.json
+++ b/sdk/js/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "Node16",
     "lib": ["ES2022"],
     "types": ["node", "jest"],
     "outDir": "./dist",
@@ -14,7 +14,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/specs/SPEC-00032-cli-planning-testing.md
+++ b/specs/SPEC-00032-cli-planning-testing.md
@@ -1,0 +1,464 @@
+# SPEC-00032: CLI-Driven Planning Feature Testing Guide
+
+**Status**: Active
+**Created**: 2026-01-07
+**Author**: System
+**Related**: SPEC-00029 (planning architecture), SPEC-00031 (SDK integration)
+
+## Overview
+
+FABER recently implemented a two-phase workflow architecture that separates planning from execution:
+- **Phase 1: Planning** - CLI batch creates workflow plans for multiple issues
+- **Phase 2: Execution** - Claude Code executes pre-made plans
+
+This specification outlines comprehensive testing procedures to validate the CLI-driven planning feature.
+
+## Background/Context
+
+### Architecture Change
+
+**Old Approach:**
+- Claude Code does both planning and execution in one session
+- Sequential: plan → execute for each issue
+- Planning is implicit/in-memory
+
+**New Approach (commits 5541ad6, 698c363, 0a0bc5e):**
+- CLI creates explicit plan artifacts (JSON files)
+- Batch planning: process 10+ issues upfront
+- Claude Code reads and executes pre-made plans
+- Plans stored at: `logs/fractary/plugins/faber/plans/{plan_id}.json`
+
+### Key Components
+
+**Commands:**
+- `/fractary-faber:plan` - Create workflow plans (uses faber-planner agent)
+- `/fractary-faber:workflow-run` - Execute existing plans (uses faber-manager agent)
+
+**Agents:**
+- `faber-planner` - Planning engine (creates plan artifacts)
+- `faber-manager` - Execution orchestrator (follows orchestration protocol)
+
+**Key Files:**
+- `cli/src/commands/plan/index.ts` - CLI plan command implementation
+- `plugins/faber/agents/faber-planner.md` - Planner agent definition
+- `plugins/faber/config/schemas/plan.schema.json` - Plan artifact schema
+- `logs/fractary/plugins/faber/plans/*.json` - Generated plans
+
+## Testing Scenarios
+
+### Test 1: Basic Planning with Work ID
+
+**Goal:** Verify plan creation for a single GitHub issue
+
+**Commands:**
+```bash
+# In Claude Code
+/fractary-faber:plan --work-id 258
+```
+
+**Expected Results:**
+1. ✅ Plan ID generated (format: `fractary-faber-258-title-YYYYMMDDTHHMMSS`)
+2. ✅ Plan file created at `logs/fractary/plugins/faber/plans/{plan_id}.json`
+3. ✅ User prompted with options:
+   - Execute plan now
+   - Review plan details
+   - Exit without executing
+4. ✅ Plan contains:
+   - Resolved workflow with inheritance chain
+   - Issue metadata (title, URL, labels)
+   - Branch name (format: `feat/258-issue-title`)
+   - Worktree path (if applicable)
+   - Autonomy settings
+
+**Validation:**
+```bash
+# Check plan file exists
+ls -la logs/fractary/plugins/faber/plans/
+cat logs/fractary/plugins/faber/plans/{plan_id}.json | jq '.'
+
+# Verify required fields
+jq '.id, .workflow.id, .items[0].work_id' logs/fractary/plugins/faber/plans/{plan_id}.json
+```
+
+---
+
+### Test 2: Batch Planning (Multiple Issues)
+
+**Goal:** Test batch planning capability
+
+**Commands:**
+```bash
+/fractary-faber:plan --work-id 258,259,260
+```
+
+**Expected Results:**
+1. ✅ Three separate plan files created
+2. ✅ Each plan has unique plan ID
+3. ✅ User shown summary of all plans
+4. ✅ Option to execute all or review individually
+
+**Validation:**
+```bash
+# Count plan files
+ls -1 logs/fractary/plugins/faber/plans/*.json | wc -l
+
+# Check each plan has correct work_id
+for file in logs/fractary/plugins/faber/plans/*.json; do
+  jq '.items[0].work_id' "$file"
+done
+```
+
+---
+
+### Test 3: Target-Based Planning (No Work ID)
+
+**Goal:** Test planning without GitHub issue
+
+**Commands:**
+```bash
+/fractary-faber:plan ipeds/admissions
+```
+
+**Expected Results:**
+1. ✅ Target matcher identifies target type
+2. ✅ Plan created with target context (no issue metadata)
+3. ✅ Branch named from target (e.g., `feat/ipeds-admissions`)
+4. ✅ Plan shows `"planning_mode": "target"`
+
+**Validation:**
+```bash
+# Check target-based plan structure
+jq '.source.planning_mode, .source.target_match' logs/fractary/plugins/faber/plans/{plan_id}.json
+```
+
+---
+
+### Test 4: Plan Execution
+
+**Goal:** Execute a pre-created plan
+
+**Setup:**
+First create a plan:
+```bash
+/fractary-faber:plan --work-id 258
+```
+
+**Commands:**
+```bash
+# Execute the plan
+/fractary-faber:workflow-run 258
+```
+
+**Expected Results:**
+1. ✅ Planner loads existing plan from logs directory
+2. ✅ Shows plan summary to user
+3. ✅ Executes workflow following orchestration protocol
+4. ✅ Updates state file at `.fractary/runs/{run_id}/state.json`
+5. ✅ Emits events to `.fractary/runs/{run_id}/events/`
+6. ✅ Respects autonomy gates and guards
+
+**Validation:**
+```bash
+# Check state file
+cat .fractary/runs/*/state.json | jq '.status, .current_phase'
+
+# Check event log
+ls -la .fractary/runs/*/events/
+```
+
+---
+
+### Test 5: Workflow Resolution & Inheritance
+
+**Goal:** Verify workflow inheritance merging
+
+**Commands:**
+```bash
+/fractary-faber:plan --work-id 258 --workflow fractary-faber:default
+```
+
+**Expected Results:**
+1. ✅ Plan contains `"inheritance_chain"` array
+2. ✅ Plan shows merged workflow with all steps from parent workflows
+3. ✅ Steps have `source` metadata showing origin workflow
+
+**Validation:**
+```bash
+# Check inheritance chain
+jq '.workflow.inheritance_chain' logs/fractary/plugins/faber/plans/{plan_id}.json
+
+# Verify merged steps from multiple sources
+jq '.workflow.phases.architect.steps[] | {id, name, source}' logs/fractary/plugins/faber/plans/{plan_id}.json
+```
+
+---
+
+### Test 6: Auto-Resume After Interruption
+
+**Goal:** Test resume functionality
+
+**Steps:**
+1. Start workflow execution:
+   ```bash
+   /fractary-faber:workflow-run 258
+   ```
+2. Interrupt during Build phase (Ctrl+C)
+3. Resume same workflow:
+   ```bash
+   /fractary-faber:workflow-run 258
+   ```
+
+**Expected Results:**
+1. ✅ Second run detects incomplete execution
+2. ✅ Shows "Incomplete run detected" message
+3. ✅ Automatically resumes from last completed step
+4. ✅ State file shows correct resume point
+
+**Validation:**
+```bash
+# Check state shows resume context
+jq '.steps[] | {step_id, status, completed_at}' .fractary/runs/*/state.json
+```
+
+---
+
+### Test 7: Plan Review Without Execution
+
+**Goal:** Create and review plan without executing
+
+**Commands:**
+```bash
+/fractary-faber:plan --work-id 258
+# User selects "Review plan details"
+```
+
+**Expected Results:**
+1. ✅ Full plan JSON displayed to user
+2. ✅ User can review workflow structure
+3. ✅ User re-prompted to execute or exit
+4. ✅ Plan remains saved for later
+
+**Validation:**
+Plan file exists but no run state:
+```bash
+ls logs/fractary/plugins/faber/plans/{plan_id}.json
+ls .fractary/runs/ | wc -l  # Should be 0 or unchanged
+```
+
+---
+
+### Test 8: Error Handling
+
+**Goal:** Test error cases
+
+**Test Cases:**
+
+#### Invalid Work ID
+```bash
+/fractary-faber:plan --work-id 99999
+```
+Expected: Error message about issue not found
+
+#### Invalid Workflow
+```bash
+/fractary-faber:plan --work-id 258 --workflow nonexistent-workflow
+```
+Expected: Error message about unknown workflow
+
+#### Missing Configuration
+```bash
+# Temporarily rename config
+mv .fractary/plugins/faber/config.json .fractary/plugins/faber/config.json.bak
+/fractary-faber:plan --work-id 258
+```
+Expected: Error about missing configuration
+
+---
+
+### Test 9: Plan Schema Validation
+
+**Goal:** Verify plan conforms to schema
+
+**Commands:**
+```bash
+# Create a plan
+/fractary-faber:plan --work-id 258
+
+# Validate against schema
+npm run validate-plan logs/fractary/plugins/faber/plans/{plan_id}.json
+```
+
+**Expected Results:**
+1. ✅ Plan passes schema validation
+2. ✅ All required fields present
+3. ✅ Field types correct (strings, numbers, booleans, arrays)
+
+---
+
+### Test 10: Orchestration Protocol Execution
+
+**Goal:** Verify execution follows protocol
+
+**Commands:**
+```bash
+/fractary-faber:workflow-run 258
+```
+
+**Check Points:**
+1. ✅ BEFORE Step: State updated, events emitted, guards executed
+2. ✅ EXECUTE Step: Commands invoked correctly (full command strings)
+3. ✅ AFTER Step: Result evaluated, state updated, events emitted
+4. ✅ TodoWrite updates show progress
+5. ✅ Phase transitions recorded
+
+**Validation:**
+```bash
+# Check event sequence
+ls -lt .fractary/runs/*/events/ | head -20
+
+# Verify state updates
+jq '.steps[] | {step_id, status, message}' .fractary/runs/*/state.json
+```
+
+---
+
+## Quick Start Testing Guide
+
+### Minimal Test (5 minutes)
+
+1. **Create a plan:**
+   ```bash
+   /fractary-faber:plan --work-id 258
+   ```
+
+2. **Review plan file:**
+   ```bash
+   cat logs/fractary/plugins/faber/plans/fractary-faber-258-*.json | jq '.'
+   ```
+
+3. **Execute plan:**
+   ```bash
+   /fractary-faber:workflow-run 258
+   ```
+
+4. **Check state:**
+   ```bash
+   cat .fractary/runs/*/state.json | jq '.status, .current_phase'
+   ```
+
+### Comprehensive Test (30 minutes)
+
+Run all 10 test scenarios above in sequence.
+
+---
+
+## Success Criteria
+
+The CLI planning feature is working correctly if:
+
+- ✅ Plans are created as valid JSON files
+- ✅ Workflow inheritance is correctly resolved
+- ✅ Plan execution loads pre-created plans
+- ✅ Orchestration protocol is followed (BEFORE → EXECUTE → AFTER)
+- ✅ State management works (updates before/after steps)
+- ✅ Event emission provides audit trail
+- ✅ Resume functionality works after interruption
+- ✅ Error handling is graceful
+- ✅ Batch planning works for multiple issues
+- ✅ Target-based planning works without work IDs
+
+---
+
+## Key Files to Monitor
+
+During testing, watch these locations:
+
+```
+logs/fractary/plugins/faber/plans/     # Plan artifacts
+.fractary/runs/{run_id}/state.json     # Execution state
+.fractary/runs/{run_id}/events/        # Event audit trail
+.fractary/plugins/faber/config.json    # Configuration
+```
+
+---
+
+## Troubleshooting
+
+### Plan Not Created
+- Check faber-planner agent is available
+- Verify work_id exists in GitHub
+- Check configuration file exists
+
+### Execution Fails
+- Verify plan file exists
+- Check workflow resolution succeeded
+- Review error in state file
+
+### Resume Not Working
+- Check state file has resume context
+- Verify run_id matches
+- Look for step completion records
+
+---
+
+## Next Steps After Testing
+
+Once testing confirms the feature works:
+
+1. Document any bugs found
+2. Create test automation scripts
+3. Update user-facing documentation
+4. Train team on new workflow
+5. Migrate existing processes to use CLI planning
+
+---
+
+## Plan Artifact Structure
+
+Plans are JSON files with the following structure:
+
+```json
+{
+  "id": "fractary-claude-plugins-csv-export-20251208T160000",
+  "created": "2025-12-08T16:00:00Z",
+  "created_by": "faber-planner",
+
+  "metadata": {
+    "org": "fractary",
+    "project": "claude-plugins",
+    "subproject": "csv-export",
+    "year": "2025", "month": "12", "day": "08"
+  },
+
+  "source": {
+    "work_id": "123",
+    "planning_mode": "work_id",
+    "target_match": null
+  },
+
+  "workflow": {
+    "id": "fractary-faber:default",
+    "resolved_at": "2025-12-08T16:00:00Z",
+    "inheritance_chain": ["fractary-faber:default", "fractary-faber:core"],
+    "phases": { /* full resolved workflow */ }
+  },
+
+  "autonomy": "guarded",
+  "items": [
+    {
+      "work_id": "123",
+      "target": "resolved-target-name",
+      "issue": { "number": 123, "title": "...", "url": "..." },
+      "branch": { "name": "feat/123-...", "status": "new|ready|resume" },
+      "worktree": "../repo-wt-feat-123-..."
+    }
+  ],
+
+  "execution": {
+    "mode": "parallel",
+    "max_concurrent": 5,
+    "status": "pending",
+    "results": []
+  }
+}
+```

--- a/specs/SPEC-00033-es-modules-compatibility-fix.md
+++ b/specs/SPEC-00033-es-modules-compatibility-fix.md
@@ -1,0 +1,223 @@
+# SPEC-00033: ES Modules Compatibility Fix for @fractary/faber SDK and CLI
+
+**Status**: Implementation
+**Created**: 2026-01-07
+**Author**: System
+**Related**: SPEC-00031 (SDK integration)
+
+## Overview
+
+Fix ES modules compatibility in the @fractary/faber SDK by adding explicit `.js` extensions to all relative import statements. This resolves runtime module resolution errors and brings the SDK to the same standard as the CLI.
+
+## Problem Statement
+
+The `@fractary/faber-cli` fails at runtime with:
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/sdk/dist/types'
+```
+
+**Root Cause**: SDK source files lack `.js` extensions on relative imports. While TypeScript auto-adds them during compilation, this creates:
+- IDE/editor tooling issues
+- Test runner compatibility problems
+- Developer confusion (source doesn't match runtime)
+- Future Node.js strict mode incompatibility
+
+## Current State Analysis
+
+### SDK (sdk/js)
+- **Source files**: Missing `.js` extensions on ~110+ relative imports
+- **Compiled dist**: Has `.js` extensions (TypeScript auto-adds)
+- **Status**: INCONSISTENT - relies on compiler magic
+
+### CLI (cli/src)
+- **Source files**: Has explicit `.js` extensions on all relative imports
+- **Compiled dist**: Has `.js` extensions (passed through)
+- **Status**: CONSISTENT ✅
+
+### Configuration
+- **SDK tsconfig**: `"module": "Node16"`, `"moduleResolution": "node16"` (strict)
+- **CLI tsconfig**: `"module": "ES2020"`, `"moduleResolution": "node"` (lenient)
+
+## Scope of Work
+
+### Files to Update
+- **Total SDK files**: 42 TypeScript files
+- **Files with relative imports**: 34 files (81%)
+- **Total import statements**: ~110+ imports to update
+- **Test files**: 6 test files
+
+### Import Patterns to Fix
+
+| Pattern | Count | Example | Transformation |
+|---------|-------|---------|----------------|
+| `from '../types'` | 20 | `import { FaberConfig } from '../types'` | → `'../types.js'` |
+| `from './types'` | 16 | `import { SpecTemplate } from './types'` | → `'./types.js'` |
+| `from '../errors'` | 10 | `import { ConfigError } from '../errors'` | → `'../errors.js'` |
+| `from '../config'` | 8 | `import { loadConfig } from '../config'` | → `'../config.js'` |
+| `from './work'` | 7 | `export * from './work'` | → `'./work/index.js'` |
+| `from './manager'` | 5 | `import { Manager } from './manager'` | → `'./manager.js'` |
+
+## Implementation Plan
+
+### Phase 1: Update SDK Import Statements
+
+#### 1.1 Simple Relative Imports
+Add `.js` extension to file imports:
+```typescript
+// Before
+import { FaberConfig } from './types';
+import { ConfigError } from '../errors';
+
+// After
+import { FaberConfig } from './types.js';
+import { ConfigError } from '../errors.js';
+```
+
+**Files affected**: 34 files with relative imports
+
+#### 1.2 Directory Imports
+Add `/index.js` to directory imports:
+```typescript
+// Before
+export * from './work';
+export * from './repo';
+
+// After
+export * from './work/index.js';
+export * from './repo/index.js';
+```
+
+**Files affected**: 12 files with directory imports
+
+#### 1.3 Test Files
+Update all test file imports (6 files):
+- `/sdk/js/src/__tests__/config.test.ts`
+- `/sdk/js/src/config/__tests__/initializer.test.ts`
+- `/sdk/js/src/spec/__tests__/manager.test.ts`
+- `/sdk/js/src/workflow/__tests__/agent-executor.test.ts`
+- `/sdk/js/src/__tests__/integration/*.test.ts` (2 files)
+
+### Phase 2: Build and Validate
+
+```bash
+# Build SDK
+npm run build --workspace=sdk/js
+
+# Build CLI
+npm run build --workspace=cli
+
+# Link and test
+npm link --workspace=cli
+fractary-faber --version
+fractary-faber --help
+```
+
+## Transformation Rules
+
+### File Imports
+```
+'./types' → './types.js'
+'../types' → '../types.js'
+'../../types' → '../../types.js'
+'./errors' → './errors.js'
+'./config' → './config.js'
+'./manager' → './manager.js'
+```
+
+### Directory Imports
+```
+'./work' → './work/index.js'
+'./repo' → './repo/index.js'
+'./spec' → './spec/index.js'
+'./logs' → './logs/index.js'
+'./state' → './state/index.js'
+'./workflow' → './workflow/index.js'
+'./storage' → './storage/index.js'
+```
+
+### Excluded Imports (No Changes)
+- External packages: `from 'zod'`, `from 'chalk'`
+- Node.js modules: `from 'fs'`, `from 'path'`
+- JSON files: None found (read dynamically)
+
+## Edge Cases
+
+### Type-Only Imports
+Still need `.js` extension:
+```typescript
+import type { FaberConfig } from './types.js';
+```
+
+### Re-Exports
+Add `.js` to re-exports:
+```typescript
+export * from './types.js';
+export { Manager } from './manager.js';
+```
+
+### Dynamic Imports
+None found in codebase (all static imports)
+
+## Critical Files (Priority Order)
+
+1. `/sdk/js/src/index.ts` - Main entry point
+2. `/sdk/js/src/config.ts` - Core configuration
+3. `/sdk/js/src/work/manager.ts` - Work manager
+4. `/sdk/js/src/repo/manager.ts` - Repository manager
+5. `/sdk/js/src/spec/manager.ts` - Specification manager
+6. Provider files in `work/providers/` and `repo/providers/`
+7. All test files
+
+## Success Criteria
+
+- ✅ All 42 SDK source files have `.js` extensions on relative imports
+- ✅ SDK builds without TypeScript errors
+- ✅ CLI builds without errors
+- ✅ `fractary-faber --version` runs successfully
+- ✅ `fractary-faber --help` shows command structure
+- ✅ No runtime module resolution errors
+- ✅ Test suite passes
+
+## Benefits
+
+1. **Consistency**: SDK matches CLI pattern (explicit `.js` extensions)
+2. **IDE Support**: Better editor tooling and error detection
+3. **Test Compatibility**: Tests run correctly with strict ESM checking
+4. **Future-Proof**: Prepares for Node.js strict ESM mode
+5. **Developer Clarity**: Source code reflects actual runtime imports
+6. **No Compiler Magic**: Explicit is better than implicit
+
+## Testing Validation
+
+After implementation:
+
+```bash
+# 1. Build packages
+npm run build --workspace=sdk/js
+npm run build --workspace=cli
+
+# 2. Link CLI locally
+npm link --workspace=cli
+
+# 3. Test basic commands
+fractary-faber --version
+fractary-faber --help
+fractary-faber plan --help
+
+# 4. Test actual plan command (with real issue)
+fractary-faber plan --work-id 258
+```
+
+## Related Documentation
+
+- TypeScript ES Modules: https://www.typescriptlang.org/docs/handbook/esm-node.html
+- Node.js ES Modules: https://nodejs.org/api/esm.html
+- SPEC-00031: FABER CLI Core SDK Integration
+
+## Notes
+
+- This fix addresses a fundamental ES modules compatibility issue
+- TypeScript's auto-transformation was masking the problem
+- Explicit `.js` extensions are the Node.js ES modules best practice
+- CLI already follows this pattern (implemented correctly from start)
+- This brings SDK to same standard, ensuring consistency across the monorepo


### PR DESCRIPTION
## Summary

This PR fixes critical ES modules compatibility issues that prevented the CLI from running. The fix involves:

- **ES Modules Imports**: Added explicit `.js` extensions to all relative imports across 42 SDK files (~110+ imports)
- **Forge Dependency**: Updated from v1.1.1 to v1.1.4 to support proper ES module exports with "import" fields
- **Version Bumps**: SDK 2.1.0 → 2.1.1, CLI 1.3.0 → 1.3.1
- **API Updates**: Updated agent-executor.ts to use new forge API methods (agentResolve, agentHealthCheck)
- **TypeScript Config**: Updated SDK tsconfig.json to strict ES modules mode (Node16, node16)

## Test Plan

- [x] SDK builds successfully with no TypeScript errors
- [x] CLI builds successfully with new versions
- [x] `fractary-faber --version` returns 1.3.1
- [x] `fractary-faber --help` displays all commands
- [x] `fractary-faber plan --help` shows plan command options
- [x] CLI properly imports and resolves all SDK modules
- [x] Forge API methods work with new v1.1.4 package.json exports

## Related Issues

Fixes ES modules compatibility errors preventing CLI execution.
Part of SPEC-00033: ES Modules Compatibility Fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)