### PR TITLE
fix: Add missing ajv dependency to CLI v1.3.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {
@@ -38,6 +38,7 @@
   "dependencies": {
     "@fractary/core": "^0.2.0",
     "@fractary/faber": "^2.1.1",
+    "ajv": "^8.12.0",
     "chalk": "^5.0.0",
     "commander": "^12.0.0"
   },

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -84,7 +84,7 @@ logs/session-*.md
  */
 function createDefaultConfig(preset: string): object {
   const baseConfig = {
-    version: '1.3.1',
+    version: '1.3.2',
     preset,
 
     // Work tracking configuration

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,7 +17,7 @@ import { createLogsCommand } from './commands/logs/index.js';
 import { createInitCommand } from './commands/init.js';
 import { createPlanCommand } from './commands/plan/index.js';
 
-const version = '1.3.1';
+const version = '1.3.2';
 
 /**
  * Create and configure the main CLI program

--- a/cli/src/lib/anthropic-client.ts
+++ b/cli/src/lib/anthropic-client.ts
@@ -149,7 +149,7 @@ export class AnthropicClient {
       ...planJson,
       plan_id: planId,
       created_by: 'cli',
-      cli_version: '1.3.1',
+      cli_version: '1.3.2',
       created_at: new Date().toISOString(),
       issue: {
         source: 'github',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,12 @@
     },
     "cli": {
       "name": "@fractary/faber-cli",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@fractary/core": "^0.2.0",
-        "@fractary/faber": "*",
+        "@fractary/faber": "^2.1.1",
+        "ajv": "^8.12.0",
         "chalk": "^5.0.0",
         "commander": "^12.0.0"
       },
@@ -10468,7 +10469,7 @@
     },
     "sdk/js": {
       "name": "@fractary/faber",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.4",


### PR DESCRIPTION
## Summary

This patch release fixes a critical issue where the globally installed CLI was unable to find the `ajv` package dependency. The package was being imported in `anthropic-client.ts` but was not declared in `package.json` dependencies.

### Issue

When running `fractary-faber` from a global npm installation, users received:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ajv' imported from ...
```

This worked locally because `ajv` was available in node_modules from other indirect dependencies, but fails in isolated global installations.

### Fix

- Added `ajv ^8.12.0` to CLI dependencies
- Bumped CLI version to 1.3.2
- Updated hardcoded version strings in source files

### Test Plan

- [x] CLI builds successfully with ajv dependency
- [x] `node cli/dist/index.js --version` returns 1.3.2
- [x] package-lock.json updated with ajv entry

### Related Issues

Fixes critical runtime error preventing CLI usage in global installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)