### PR TITLE
fix: Improve WSL auth setup experience with Windows path conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-01-08
+
+### Fixed
+
+- **WSL Auth Setup**: Fixed `fractary-faber auth setup` command on WSL to display Windows-formatted paths (e.g., `C:\GitHub\...`) instead of WSL paths (e.g., `/mnt/c/GitHub/...`). The command now:
+  - Converts WSL paths to Windows format for easy copy-paste
+  - Shows clear instructions for opening the manifest file in Windows browsers
+  - Skips xdg-open on WSL to prevent opening in WSL Firefox where users aren't authenticated
+  - Makes the GitHub App setup flow work seamlessly on WSL environments
+
 ## [1.3.16] - 2026-01-08
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Fixed the `fractary-faber auth setup` command on WSL to display Windows-formatted paths and clear instructions instead of attempting to open files in WSL Firefox where users cannot authenticate.

## Changes
- Convert WSL paths (`/mnt/c/...`) to Windows format (`C:\...`) for easy copy-paste
- Display file path prominently instead of trying to auto-open in WSL Firefox
- Add clear instructions for opening the manifest file in Windows browsers
- Skip `xdg-open` on WSL to prevent opening unauthenticated Firefox
- Bump CLI version to 1.4.1 and update CHANGELOG

## Testing
The fix improves the UX on WSL by:
1. Showing a Windows path users can easily copy
2. Providing Win+R and File Explorer instructions
3. Silently skipping the failed xdg-open attempt
4. Still attempting auto-open on native macOS/Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)