### PR TITLE
fix: Support faber-workflow label prefix and update config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-01-09
+
+### Fixed
+
+- **Workflow Label Detection**: Now supports both `workflow:` and `faber-workflow:` label prefixes
+  - Fixes issue where `faber-workflow:dataset-loader-deploy` labels were not recognized
+  - Extracts workflow name correctly from either prefix format
+
+- **Workflow Config Location**: Updated default workflow configuration paths
+  - New default: `.fractary/faber/workflows/` (aligned with non-plugin architecture)
+  - Legacy support: `.fractary/plugins/faber/workflows/` (backward compatible)
+  - Automatically detects and uses existing workflow directories
+  - Migration path from old "plugins" structure to new flat structure
+
 ## [1.4.3] - 2026-01-09
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/commands/plan/index.ts
+++ b/cli/src/commands/plan/index.ts
@@ -333,10 +333,14 @@ async function assignWorkflows(
     }
 
     if (!workflow) {
-      // Extract from issue labels
-      const workflowLabel = issue.labels.find(label => label.startsWith('workflow:'));
+      // Extract from issue labels - support both 'workflow:' and 'faber-workflow:' prefixes
+      const workflowLabel = issue.labels.find(label =>
+        label.startsWith('workflow:') || label.startsWith('faber-workflow:')
+      );
       if (workflowLabel) {
-        workflow = workflowLabel.replace('workflow:', '');
+        workflow = workflowLabel
+          .replace(/^workflow:/, '')
+          .replace(/^faber-workflow:/, '');
         // Validate extracted workflow name
         validateWorkflowName(workflow);
       }

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -79,9 +79,27 @@ export class ConfigManager {
     }
 
     if (!config.workflow?.config_path) {
+      // Try new location first, fall back to legacy location for backward compatibility
+      const newPath = path.join(process.cwd(), '.fractary', 'faber', 'workflows');
+      const legacyPath = path.join(process.cwd(), '.fractary', 'plugins', 'faber', 'workflows');
+
+      let workflowPath = newPath;
+      try {
+        await fs.access(newPath);
+      } catch {
+        // New path doesn't exist, try legacy path
+        try {
+          await fs.access(legacyPath);
+          workflowPath = legacyPath;
+        } catch {
+          // Neither exists, use new path as default (will be created if needed)
+          workflowPath = newPath;
+        }
+      }
+
       config.workflow = {
         ...config.workflow,
-        config_path: path.join(process.cwd(), 'plugins', 'faber', 'config', 'workflows'),
+        config_path: workflowPath,
       };
     }
 


### PR DESCRIPTION
## Summary
Fixes workflow label detection and updates workflow configuration paths to support the new non-plugin architecture.

## Issues Fixed

### 1. Workflow Label Detection
**Problem**: Labels with `faber-workflow:` prefix were not recognized
- Only looked for `workflow:` prefix
- Labels like `faber-workflow:dataset-loader-deploy` were ignored

**Solution**: Support both prefixes
- Detects both `workflow:` and `faber-workflow:` label formats
- Correctly extracts workflow name from either prefix

### 2. Workflow Config Location
**Problem**: Default path was outdated and didn't support new architecture
- Hardcoded to `plugins/faber/config/workflows`
- No support for new `.fractary/faber/` structure

**Solution**: Smart path detection with backward compatibility
- New default: `.fractary/faber/workflows/`
- Legacy support: `.fractary/plugins/faber/workflows/`
- Automatically detects which directory exists and uses it
- Provides clean migration path from "plugins" to flat structure

## Changes
- `cli/src/commands/plan/index.ts`: Enhanced label detection to support both prefixes
- `cli/src/lib/config.ts`: Updated workflow path detection with fallback logic
- `cli/package.json`: Bumped version to 1.4.4
- `CHANGELOG.md`: Documented fixes

## Testing
Test with issue containing `faber-workflow:dataset-loader-deploy` label:
```bash
fractary-faber plan --work-label "faber-workflow:dataset-loader-deploy"
```

Should now:
- ✅ Recognize the workflow label
- ✅ Find custom workflows in `.fractary/plugins/faber/workflows/` (legacy)
- ✅ Support `.fractary/faber/workflows/` for new projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)