### PR TITLE
fix: Correct faber-cloud plugin manifest agents field format

### DIFF
--- a/plugins/faber-cloud/.claude-plugin/plugin.json
+++ b/plugins/faber-cloud/.claude-plugin/plugin.json
@@ -3,6 +3,22 @@
   "version": "3.0.1",
   "description": "Infrastructure lifecycle management for Claude Code - architect, engineer, test, and deploy cloud infrastructure (FABER workflow). Includes audit for non-destructive observability. For operations monitoring, use fractary-helm-cloud.",
   "commands": "./commands/",
-  "agents": "./agents/",
+  "agents": [
+    "./agents/adopt-agent.md",
+    "./agents/architect-agent.md",
+    "./agents/audit-agent.md",
+    "./agents/debug-agent.md",
+    "./agents/deploy-apply-agent.md",
+    "./agents/deploy-plan-agent.md",
+    "./agents/direct-agent.md",
+    "./agents/engineer-agent.md",
+    "./agents/init-agent.md",
+    "./agents/list-agent.md",
+    "./agents/manage-agent.md",
+    "./agents/status-agent.md",
+    "./agents/teardown-agent.md",
+    "./agents/test-agent.md",
+    "./agents/validate-agent.md"
+  ],
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- Fixed plugin.json manifest validation error in faber-cloud plugin
- Changed agents field from directory path to array of agent file paths
- Aligns with manifest format used by other plugins (faber, faber-article)

## Test plan
- Run `/doctor` to verify plugin loads without validation errors
- All 15 agent files are now properly referenced in the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)