### PR TITLE
fix: Remove namespace prefix from agent name fields in frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     },
     "metadata": {
       "description": "Production-ready workflow orchestration.",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "pluginRoot": "./plugins"
     },
     "plugins": [
@@ -15,7 +15,7 @@
         "name": "fractary-faber",
         "source": "./plugins/faber",
         "description": "Universal SDLC workflow framework - Frame → Architect → Build → Evaluate → Release",
-        "version": "3.4.1",
+        "version": "3.5.1",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"
@@ -108,7 +108,7 @@
         "name": "fractary-faber-article",
         "source": "./plugins/faber-article",
         "description": "Content creation lifecycle automation for blog articles - ideate, research, outline, draft, enhance, optimize SEO, generate hero images, and publish with AI assistance",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "author": {
           "name": "The Fractary",
           "url": "https://github.com/fractary"

--- a/plugins/faber-article/.claude-plugin/plugin.json
+++ b/plugins/faber-article/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber-article",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Content creation lifecycle automation for blog articles - ideate, research, outline, draft, enhance, optimize SEO, generate hero images, and publish with AI assistance. Supports configurable research depth (basic/moderate/deep), semi-automated workflow checkpoints, state tracking (idea → outline → draft → review → seo → scheduled → published), and brand voice consistency.",
   "commands": "./commands/",
   "agents": [

--- a/plugins/faber-article/agents/content-manager.md
+++ b/plugins/faber-article/agents/content-manager.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber-article:content-manager
+name: content-manager
 model: claude-opus-4-5
 description: |
   Orchestrate multi-step content workflows - research, outline, draft, enhance, optimize SEO,

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Universal SDLC workflow framework with unified orchestrator pattern (plan + run)",
   "commands": "./commands/",
   "agents": [

--- a/plugins/faber/agents/faber-initializer.md
+++ b/plugins/faber/agents/faber-initializer.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber:faber-initializer
+name: faber-initializer
 description: Initialize FABER project configuration with intelligent defaults
 model: claude-sonnet-4-5
 tools: Bash, Read, Write, Glob, AskUserQuestion

--- a/plugins/faber/agents/session-manager.md
+++ b/plugins/faber/agents/session-manager.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber:session-manager
+name: session-manager
 description: Manages critical context artifacts and session metadata during FABER workflow execution
 model: claude-sonnet-4-5
 tools: Read, Write, Glob, Bash, Skill

--- a/plugins/faber/agents/workflow-auditor.md
+++ b/plugins/faber/agents/workflow-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber:workflow-auditor
+name: workflow-auditor
 description: Validates FABER workflow configuration and reports issues with completeness scoring
 model: claude-sonnet-4-5
 tools: Read, Write, Glob, Bash

--- a/plugins/faber/agents/workflow-debugger.md
+++ b/plugins/faber/agents/workflow-debugger.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber:workflow-debugger
+name: workflow-debugger
 description: Diagnoses FABER workflow issues and proposes solutions using knowledge base patterns
 model: claude-sonnet-4-5
 tools: Read, Write, Glob, Bash, Skill

--- a/plugins/faber/agents/workflow-status.md
+++ b/plugins/faber/agents/workflow-status.md
@@ -1,5 +1,5 @@
 ---
-name: fractary-faber:workflow-status
+name: workflow-status
 description: Displays FABER workflow status combining current state with historical logs
 model: claude-sonnet-4-5
 tools: Read, Glob, Bash, Skill


### PR DESCRIPTION
## Summary
Remove redundant namespace prefixes from agent markdown frontmatter `name` fields. The plugin system automatically prepends the namespace from `plugin.json`, so including it in the agent name causes double-namespacing during registration (e.g., `fractary-faber:fractary-faber:workflow-auditor`).

## Changes
Updates 6 agent markdown files to remove namespace prefixes:
- `fractary-faber:workflow-auditor` → `workflow-auditor`
- `fractary-faber:workflow-status` → `workflow-status`
- `fractary-faber:workflow-debugger` → `workflow-debugger`
- `fractary-faber:session-manager` → `session-manager`
- `fractary-faber:faber-initializer` → `faber-initializer`
- `fractary-faber-article:content-manager` → `content-manager`

## Test plan
- Verify agents are registered with correct single-namespace format
- Test agent invocation via skills/commands
- Confirm no "Agent type 'X' not found" errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)