### PR TITLE
Define common entity term for workflows

### DIFF
--- a/plugins/faber/config/workflow.schema.json
+++ b/plugins/faber/config/workflow.schema.json
@@ -21,6 +21,11 @@
       "type": "string",
       "description": "Human-readable workflow description"
     },
+    "asset_type": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "The type of asset this workflow operates on (e.g., 'software-feature', 'blog-post', 'dataset', 'video', 'catalog'). Identifies what kind of thing the workflow creates, modifies, or manages. Projects may have multiple workflows operating on different asset types."
+    },
     "extends": {
       "type": "string",
       "description": "Parent workflow to extend. Use namespaced format: 'fractary-faber:default' for core workflows, or unnamespaced for project workflows. Parent pre_steps execute before child steps, parent post_steps execute after."

--- a/plugins/faber/config/workflows/README.md
+++ b/plugins/faber/config/workflows/README.md
@@ -26,6 +26,7 @@ Workflows are now stored as separate JSON files instead of being embedded in the
 **General-purpose workflow** for various development tasks.
 
 - **Extends**: core.json
+- **Asset Type**: `code-change`
 - **Phases**: Frame → Architect → Build → Evaluate → Release
 - **Use case**: General development, maintenance, chores, refactoring
 - **Autonomy**: Guarded (pauses before release)
@@ -36,6 +37,7 @@ Workflows are now stored as separate JSON files instead of being embedded in the
 **Optimized workflow** for bug fixes and regression prevention.
 
 - **Extends**: core.json
+- **Asset Type**: `bug-fix`
 - **Phases**: Frame → Architect → Build → Evaluate → Release
 - **Use case**: Bug fixes, defects, regressions, urgent issues
 - **Autonomy**: Guarded (pauses before release)
@@ -51,6 +53,7 @@ Workflows are now stored as separate JSON files instead of being embedded in the
 **Comprehensive workflow** for new feature development.
 
 - **Extends**: core.json
+- **Asset Type**: `software-feature`
 - **Phases**: Frame → Architect → Build → Evaluate → Release
 - **Use case**: New features, enhancements, significant changes
 - **Autonomy**: Guarded (pauses before release)
@@ -72,6 +75,7 @@ Each workflow file follows the workflow.schema.json structure:
   "$schema": "../workflow.schema.json",
   "id": "workflow-name",
   "description": "Human-readable description",
+  "asset_type": "software-feature",
   "phases": {
     "frame": { ... },
     "architect": { ... },
@@ -83,6 +87,26 @@ Each workflow file follows the workflow.schema.json structure:
   "autonomy": { ... }
 }
 ```
+
+### Asset Type
+
+The `asset_type` field identifies what type of thing the workflow operates on or produces. This is important because:
+
+- **Semantic clarity**: Different workflows may produce different types of deliverables (features, bug fixes, datasets, articles, videos)
+- **Project flexibility**: A single project may have multiple workflows operating on different asset types
+- **Entity tracking**: When entity state tracking is enabled, the asset type helps categorize and organize workflow outputs
+
+**Common asset types for software development:**
+- `code-change` - General code modifications
+- `software-feature` - New feature implementations
+- `bug-fix` - Bug fix implementations
+
+**Asset types for other domains:**
+- `blog-post` - Content creation workflows
+- `dataset` - Data pipeline workflows
+- `video` - Media production workflows
+- `catalog` - Collection management workflows
+- `api-module` - API development workflows
 
 ## Using Workflows
 

--- a/plugins/faber/config/workflows/bug.json
+++ b/plugins/faber/config/workflows/bug.json
@@ -2,6 +2,7 @@
   "$schema": "../workflow.schema.json",
   "id": "bug",
   "description": "Optimized workflow for bug fixes with emphasis on root cause analysis, minimal scope, and regression testing",
+  "asset_type": "bug-fix",
   "extends": "fractary-faber:core",
   "phases": {
     "frame": {

--- a/plugins/faber/config/workflows/default.json
+++ b/plugins/faber/config/workflows/default.json
@@ -2,6 +2,7 @@
   "$schema": "../workflow.schema.json",
   "id": "default",
   "description": "Default FABER workflow for software development - extends core with spec generation and implementation",
+  "asset_type": "code-change",
   "extends": "fractary-faber:core",
   "phases": {
     "frame": {

--- a/plugins/faber/config/workflows/feature.json
+++ b/plugins/faber/config/workflows/feature.json
@@ -2,6 +2,7 @@
   "$schema": "../workflow.schema.json",
   "id": "feature",
   "description": "Comprehensive workflow for new features with full design, testing, and documentation requirements",
+  "asset_type": "software-feature",
   "extends": "fractary-faber:core",
   "phases": {
     "frame": {

--- a/plugins/faber/docs/workflow-guide.md
+++ b/plugins/faber/docs/workflow-guide.md
@@ -56,6 +56,39 @@ FABER v2.2 introduces **workflow inheritance**, allowing you to extend existing 
 
 See [MIGRATION-v2.2.md](./MIGRATION-v2.2.md) for complete inheritance documentation.
 
+### Asset Types
+
+Each workflow operates on a specific type of **asset** - the thing being created, modified, or managed. The `asset_type` field in a workflow definition declares what kind of deliverable the workflow produces.
+
+**Why asset types matter:**
+- **Semantic clarity**: Different workflows produce different types of deliverables
+- **Project flexibility**: A single project may have multiple workflows for different asset types
+- **Entity tracking**: Asset types help categorize and organize workflow outputs
+
+**Built-in software development asset types:**
+| Workflow | Asset Type | Description |
+|----------|------------|-------------|
+| default | `code-change` | General code modifications |
+| feature | `software-feature` | New feature implementations |
+| bug | `bug-fix` | Bug fix implementations |
+
+**Example workflow with asset_type:**
+```json
+{
+  "id": "data-pipeline",
+  "asset_type": "dataset",
+  "description": "Workflow for processing and publishing datasets",
+  "extends": "fractary-faber:core",
+  "phases": { ... }
+}
+```
+
+**Common asset types by domain:**
+- **Software**: `code-change`, `software-feature`, `bug-fix`, `api-module`
+- **Content**: `blog-post`, `article`, `documentation`
+- **Data**: `dataset`, `catalog`, `collection`
+- **Media**: `video`, `image-set`, `podcast-episode`
+
 ### The 5 Phases
 
 ```

--- a/plugins/faber/skills/core/scripts/workflow-validate.sh
+++ b/plugins/faber/skills/core/scripts/workflow-validate.sh
@@ -117,6 +117,12 @@ else
     echo -e "${GREEN}✓${NC} Description: $DESCRIPTION"
 fi
 
+# Check asset_type (optional but informational)
+ASSET_TYPE=$(echo "$WORKFLOW" | jq -r '.asset_type // empty')
+if [ -n "$ASSET_TYPE" ]; then
+    echo -e "${GREEN}✓${NC} Asset type: $ASSET_TYPE"
+fi
+
 # Check phases
 PHASES=$(echo "$WORKFLOW" | jq -r '.phases // empty')
 if [ -z "$PHASES" ] || [ "$PHASES" = "null" ]; then


### PR DESCRIPTION
Introduce the concept of "asset" as the standard term for the thing a FABER workflow operates on. Each workflow can now declare its asset_type to identify what kind of deliverable it produces (e.g., software-feature, bug-fix, dataset, blog-post, video).

Changes:
- Add asset_type field to workflow.schema.json with lowercase/hyphen pattern
- Update workflow validation script to display asset_type when present
- Add asset_type to default (code-change), feature (software-feature), and bug (bug-fix) workflows
- Document asset_type concept in workflow guide and workflows README

This enables projects with multiple workflows operating on different types of deliverables to clearly identify what each workflow produces.