### PR TITLE
fix: remove stale init-agent.md reference from faber-cloud plugin

### DIFF
--- a/plugins/faber-cloud/.claude-plugin/plugin.json
+++ b/plugins/faber-cloud/.claude-plugin/plugin.json
@@ -12,7 +12,6 @@
     "./agents/deploy-plan-agent.md",
     "./agents/direct-agent.md",
     "./agents/engineer-agent.md",
-    "./agents/init-agent.md",
     "./agents/list-agent.md",
     "./agents/manage-agent.md",
     "./agents/status-agent.md",


### PR DESCRIPTION
## Summary
- Removes non-existent init-agent.md file reference from faber-cloud plugin.json
- Fixes plugin validation errors in Claude Code /doctor command

## Test plan
- Run `/doctor` command and verify fractary-faber-cloud plugin no longer shows path not found errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)