### PR TITLE
Set all Faber agents to orange color

### DIFF
--- a/plugins/faber/agents/agent-auditor.md
+++ b/plugins/faber/agents/agent-auditor.md
@@ -8,7 +8,7 @@ description: |
   - Score or grade agent implementations
 model: claude-sonnet-4-5
 tools: Read, Glob, Grep
-color: green
+color: orange
 ---
 
 # Agent Auditor

--- a/plugins/faber/agents/agent-engineer.md
+++ b/plugins/faber/agents/agent-engineer.md
@@ -12,7 +12,7 @@ description: |
   Examples: "create an agent that validates configs", "make a bot to generate reports", "update the spec-generator to support markdown", "add error handling to the planner agent"
 model: claude-opus-4-5
 tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
-color: blue
+color: orange
 ---
 
 # Agent Engineer

--- a/plugins/faber/agents/configurator.md
+++ b/plugins/faber/agents/configurator.md
@@ -3,7 +3,7 @@ name: configurator
 description: Comprehensive FABER configuration manager - handles initialization, updates, and management
 model: claude-haiku-4-5
 tools: Bash, Read, Write, Glob, AskUserQuestion
-color: blue
+color: orange
 ---
 
 # FABER Configuration Manager


### PR DESCRIPTION
All Faber agents should have consistent orange color. Updated:
- agent-auditor.md: green → orange
- agent-engineer.md: blue → orange
- configurator.md: blue → orange