### PR TITLE
feat: Align workflow path configuration to .fractary/faber/workflows/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-01-16
+
+### Version Bumps
+
+| Component | Version | Change |
+|-----------|---------|--------|
+| CLI (@fractary/faber-cli) | 1.5.1 | Patch |
+| faber plugin | 3.6.1 | Patch |
+
+### Changed
+
+- **BREAKING**: Unified workflow path configuration to `.fractary/faber/workflows/`
+  - Configurator agent now writes to `faber:` section in `.fractary/config.yaml` (not standalone `.fractary/faber/config.yaml`)
+  - Removed legacy fallback logic in CLI that checked `.fractary/plugins/faber/workflows/`
+  - `merge-workflows.sh` project namespace now resolves to `.fractary/faber/workflows/`
+  - Updated `config.schema.json` default project namespace example
+  - Updated all documentation to reflect new paths
+
+### Removed
+
+- Backward compatibility for `.fractary/plugins/faber/workflows/` path (use `.fractary/faber/workflows/` instead)
+- Legacy config fallback logic in CLI `config.ts`
+
 ## [1.5.0] - 2026-01-16
 
 ### Version Bumps

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/lib/__tests__/config.test.ts
+++ b/cli/src/lib/__tests__/config.test.ts
@@ -238,7 +238,7 @@ describe('ConfigManager', () => {
 
       const config = await ConfigManager.load();
 
-      expect(config.workflow?.config_path).toBe('/project/plugins/faber/config/workflows');
+      expect(config.workflow?.config_path).toBe('/project/.fractary/faber/workflows');
     });
 
     it('should use workflow config from FABER config file', async () => {
@@ -287,7 +287,7 @@ describe('ConfigManager', () => {
       const config = await ConfigManager.load();
 
       expect(config.worktree?.location).toBe('/home/testuser/.claude-worktrees');
-      expect(config.workflow?.config_path).toBe('/project/plugins/faber/config/workflows');
+      expect(config.workflow?.config_path).toBe('/project/.fractary/faber/workflows');
     });
 
     it('should merge partial configs correctly', async () => {

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -96,23 +96,8 @@ export class ConfigManager {
     }
 
     if (!config.workflow?.config_path) {
-      // Try new location first, fall back to legacy location for backward compatibility
-      const newPath = path.join(process.cwd(), '.fractary', 'faber', 'workflows');
-      const legacyPath = path.join(process.cwd(), '.fractary', 'plugins', 'faber', 'workflows');
-
-      let workflowPath = newPath;
-      try {
-        await fs.access(newPath);
-      } catch {
-        // New path doesn't exist, try legacy path
-        try {
-          await fs.access(legacyPath);
-          workflowPath = legacyPath;
-        } catch {
-          // Neither exists, use new path as default (will be created if needed)
-          workflowPath = newPath;
-        }
-      }
+      // Always use the canonical workflow path - no legacy fallback
+      const workflowPath = path.join(process.cwd(), '.fractary', 'faber', 'workflows');
 
       config.workflow = {
         ...config.workflow,

--- a/plugins/faber/.claude-plugin/plugin.json
+++ b/plugins/faber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fractary-faber",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Universal SDLC workflow framework with unified orchestrator pattern (plan + run)",
   "commands": "./commands/",
   "agents": [

--- a/plugins/faber/README.md
+++ b/plugins/faber/README.md
@@ -33,7 +33,7 @@ cd your-project
 /fractary-faber:configure
 ```
 
-This auto-detects your project settings and creates `.fractary/plugins/faber/config.json`.
+This auto-detects your project settings and creates the `faber:` section in `.fractary/config.yaml`.
 
 ### 2. Configure Authentication
 

--- a/plugins/faber/config/config.schema.json
+++ b/plugins/faber/config/config.schema.json
@@ -162,7 +162,7 @@
           },
           "examples": [
             {
-              "project": ".fractary/plugins/faber/workflows",
+              "project": ".fractary/faber/workflows",
               "fractary-faber": "~/.claude/plugins/marketplaces/fractary/plugins/faber/workflows"
             }
           ]

--- a/plugins/faber/config/workflows/README.md
+++ b/plugins/faber/config/workflows/README.md
@@ -112,21 +112,17 @@ The `asset_type` field identifies what type of thing the workflow operates on or
 
 ### In Config File
 
-Reference workflows in `.fractary/plugins/faber/config.json`:
+Reference workflows in `.fractary/config.yaml` (faber: section):
 
-```json
-{
-  "workflows": [
-    {
-      "id": "default",
-      "file": "./workflows/default.json"
-    },
-    {
-      "id": "hotfix",
-      "file": "./workflows/hotfix.json"
-    }
-  ]
-}
+```yaml
+faber:
+  workflow:
+    config_path: ".fractary/faber/workflows"
+  workflows:
+    - id: default
+      file: "./workflows/default.json"
+    - id: hotfix
+      file: "./workflows/hotfix.json"
 ```
 
 ### Selecting Workflow
@@ -291,7 +287,7 @@ If no `--workflow` flag is provided AND no labels match, uses the first workflow
 
 1. **Copy a template**:
    ```bash
-   cp plugins/faber/config/workflows/default.json .fractary/plugins/faber/workflows/custom.json
+   cp plugins/faber/config/workflows/default.json .fractary/faber/workflows/custom.json
    ```
 
 2. **Edit workflow** to meet your needs:
@@ -300,17 +296,13 @@ If no `--workflow` flag is provided AND no labels match, uses the first workflow
    - Adjust autonomy level
    - Customize validation
 
-3. **Reference in config**:
-   ```json
-   {
-     "workflows": [
-       {
-         "id": "custom",
-         "file": "./workflows/custom.json",
-         "description": "My custom workflow"
-       }
-     ]
-   }
+3. **Reference in config** (`.fractary/config.yaml`):
+   ```yaml
+   faber:
+     workflows:
+       - id: custom
+         file: "./workflows/custom.json"
+         description: "My custom workflow"
    ```
 
 4. **Validate**:

--- a/plugins/faber/docs/PROJECT-INTEGRATION-GUIDE.md
+++ b/plugins/faber/docs/PROJECT-INTEGRATION-GUIDE.md
@@ -75,45 +75,40 @@ Map your workflow steps to FABER's 5 phases:
 /fractary-faber:configure
 
 # This creates:
-# - .fractary/plugins/faber/config.json (main config with workflow references)
-# - .fractary/plugins/faber/workflows/default.json (standard workflow)
-# - .fractary/plugins/faber/workflows/hotfix.json (expedited workflow)
+# - .fractary/config.yaml with faber: section (unified config)
+# - .fractary/faber/workflows/ directory for project-specific workflows
 ```
 
 **Directory structure created:**
 ```
-.fractary/plugins/faber/
-├── config.json              # Main configuration (references workflows)
-└── workflows/               # Workflow definition files
-    ├── default.json         # Standard FABER workflow
-    └── hotfix.json          # Expedited hotfix workflow
+.fractary/
+├── config.yaml              # Unified config (faber: section for FABER settings)
+└── faber/
+    └── workflows/           # Project-specific workflow files
 ```
 
 ### Step 4: Customize Workflows
 
-Edit workflow files in `.fractary/plugins/faber/workflows/` to match your tools.
+Edit workflow files in `.fractary/faber/workflows/` to match your tools.
 
-**Main config** (`.fractary/plugins/faber/config.json`) references workflows:
-```json
-{
-  "workflows": [
-    {
-      "id": "default",
-      "file": "./workflows/default.json",
-      "description": "Standard FABER workflow"
-    },
-    {
-      "id": "hotfix",
-      "file": "./workflows/hotfix.json",
-      "description": "Expedited workflow for critical patches"
-    }
-  ],
-  "integrations": { ... },
-  "logging": { ... }
-}
+**Unified config** (`.fractary/config.yaml`) contains FABER settings in the `faber:` section:
+```yaml
+faber:
+  workflow:
+    config_path: ".fractary/faber/workflows"
+    autonomy: "guarded"
+  workflows:
+    - id: default
+      file: "./workflows/default.json"
+      description: "Standard FABER workflow"
+    - id: hotfix
+      file: "./workflows/hotfix.json"
+      description: "Expedited workflow for critical patches"
+  logging:
+    use_logs_plugin: true
 ```
 
-**Workflow files** contain phase definitions. Edit `.fractary/plugins/faber/workflows/default.json`:
+**Workflow files** contain phase definitions. Edit `.fractary/faber/workflows/default.json`:
 ```json
 {
   "$schema": "../workflow.schema.json",
@@ -137,29 +132,23 @@ To add custom workflows:
 
 1. **Copy a template**:
    ```bash
-   cp .fractary/plugins/faber/workflows/default.json .fractary/plugins/faber/workflows/documentation.json
+   cp .fractary/faber/workflows/default.json .fractary/faber/workflows/documentation.json
    ```
 
 2. **Edit the new workflow file** to customize phases and steps
 
-3. **Add reference to config.json**:
-   ```json
-   {
-     "workflows": [
-       {
-         "id": "default",
-         "file": "./workflows/default.json",
-         "description": "Standard FABER workflow"
-         // KEEP THIS - it's your baseline workflow
-       },
-       {
-         "id": "documentation",
-         "file": "./workflows/documentation.json",
-         "description": "Documentation-only workflow"
-         // ADD custom workflows alongside default
-       }
-     ]
-   }
+3. **Add reference to .fractary/config.yaml faber: section**:
+   ```yaml
+   faber:
+     workflows:
+       - id: default
+         file: "./workflows/default.json"
+         description: "Standard FABER workflow"
+         # KEEP THIS - it's your baseline workflow
+       - id: documentation
+         file: "./workflows/documentation.json"
+         description: "Documentation-only workflow"
+         # ADD custom workflows alongside default
    ```
 
 **Always keep the default workflow** as your fallback for general development.
@@ -533,7 +522,7 @@ When integrating FABER into your project, use the plugin commands directly in yo
 
 **✅ Do This Instead:**
 - Use `/fractary-faber:*` commands directly
-- Customize behavior via `.fractary/plugins/faber/config.json`
+- Customize behavior via `.fractary/config.yaml` (faber: section)
 - Add project-specific logic via phase hooks
 - Extend via plugin system (see PLUGIN-EXTENSION-GUIDE.md)
 

--- a/plugins/faber/docs/configuration.md
+++ b/plugins/faber/docs/configuration.md
@@ -19,17 +19,18 @@ Complete guide to configuring FABER workflow for your projects using the new JSO
 # Generate default FABER configuration
 /fractary-faber:configure
 
-# This creates .fractary/plugins/faber/config.json with baseline workflow
+# This creates the faber: section in .fractary/config.yaml
+# and sets up .fractary/faber/workflows/ for project workflows
 ```
 
 ### Option 2: Manual Configuration
 
 ```bash
 # Copy example configuration
-cp plugins/faber/config/faber.example.json .fractary/plugins/faber/config.json
+cp plugins/faber/config/faber.example.json .fractary/faber/config.json
 
-# Customize for your project
-vim .fractary/plugins/faber/config.json
+# Or edit the unified config directly
+vim .fractary/config.yaml  # Add/edit faber: section
 ```
 
 ### After Initialization
@@ -45,22 +46,23 @@ vim .fractary/plugins/faber/config.json
 
 ## Configuration File Location
 
-**Directory structure (v2.0)**:
+**Directory structure (v2.1+)**:
 ```
-.fractary/plugins/faber/
-|-- config.json              # Main configuration (references workflows)
-|-- workflows/               # Workflow definition files
-    |-- default.json         # Standard FABER workflow
-    |-- hotfix.json          # Expedited hotfix workflow
-    |-- custom.json          # Your custom workflows
-```
-
-**Old location (v1.x) - NO LONGER USED**:
-```
-.faber.config.toml
+.fractary/
+|-- config.yaml              # Unified config (faber: section contains FABER settings)
+|-- faber/
+    |-- workflows/           # Project-specific workflow files
+        |-- custom.json      # Your custom workflows
 ```
 
-The configuration uses JSON format and follows the standard Fractary plugin configuration pattern. Workflows are now stored as separate files (referenced by config.json) instead of being embedded inline.
+**Old locations (DEPRECATED - NO LONGER USED)**:
+```
+.fractary/plugins/faber/     # Legacy location - migrate to .fractary/faber/
+.fractary/faber/config.yaml  # Legacy standalone config - use unified config instead
+.faber.config.toml           # v1.x location - no longer used
+```
+
+FABER configuration is now in the `faber:` section of the unified `.fractary/config.yaml` file. Project-specific workflows go in `.fractary/faber/workflows/`.
 
 ## Workflow Resolution Order
 
@@ -68,8 +70,8 @@ When FABER resolves a workflow, it searches in a specific order. Understanding t
 
 ### Resolution Precedence (Highest to Lowest)
 
-1. **Project Workflows** (`.fractary/plugins/faber/workflows/`)
-   - Workflows defined in your project's `.fractary/` directory
+1. **Project Workflows** (`.fractary/faber/workflows/`)
+   - Workflows defined in your project's `.fractary/faber/` directory
    - Use `project:` namespace prefix (or no prefix)
    - Example: `project:custom-workflow` or just `custom-workflow`
 
@@ -96,7 +98,7 @@ When FABER resolves a workflow, it searches in a specific order. Understanding t
 When you specify `--workflow my-workflow`:
 
 ```
-1. Check: .fractary/plugins/faber/workflows/my-workflow.json
+1. Check: .fractary/faber/workflows/my-workflow.json
    - If found: Use it (project workflow)
    - If not found: Continue
 
@@ -176,7 +178,7 @@ These workflows are maintained in the plugin source code and update automaticall
 
 **For most projects**: Simply run `/fractary-faber:configure` and use the default workflow as-is. The config will reference `fractary-faber:default` which provides a complete software development workflow.
 
-**For custom needs**: Create project-specific workflows in `.fractary/plugins/faber/workflows/` that extend either `fractary-faber:core` or `fractary-faber:default`.
+**For custom needs**: Create project-specific workflows in `.fractary/faber/workflows/` that extend either `fractary-faber:core` or `fractary-faber:default`.
 
 ### Main Configuration File (config.json)
 
@@ -276,12 +278,12 @@ Projects can define multiple workflows for different scenarios. The `/fractary-f
 **Creating custom workflows:**
 ```bash
 # Copy a template as starting point
-cp .fractary/plugins/faber/workflows/default.json .fractary/plugins/faber/workflows/documentation.json
+cp .fractary/faber/workflows/default.json .fractary/faber/workflows/documentation.json
 
 # Edit the new workflow file
-vim .fractary/plugins/faber/workflows/documentation.json
+vim .fractary/faber/workflows/documentation.json
 
-# Add reference to config.json workflows array
+# Add reference to .fractary/config.yaml faber: section
 # Then validate
 /fractary-faber:audit
 ```

--- a/plugins/faber/skills/agent-type-configurator/SKILL.md
+++ b/plugins/faber/skills/agent-type-configurator/SKILL.md
@@ -173,7 +173,8 @@ The `configurator` agent is the canonical configurator example:
 - Initialize mode for new projects
 - Update mode with `--context` natural language changes
 - Auto-detects repository info from git
-- Creates `.fractary/faber/config.yaml`
+- Writes `faber:` section in `.fractary/config.yaml` (unified config)
+- Sets `workflow.config_path: ".fractary/faber/workflows"`
 - Manages `.fractary/.gitignore` entries
 - Supports `--force` and `--json` flags
 

--- a/plugins/faber/skills/agent-type-configurator/standards.md
+++ b/plugins/faber/skills/agent-type-configurator/standards.md
@@ -107,12 +107,12 @@ Example:
 ```
 ERROR: Invalid configuration syntax
 
-File: .fractary/faber/config.yaml
+File: .fractary/config.yaml (faber: section)
 Error: Unexpected mapping at line 42
 
 Recovery:
 1. Check for syntax errors (missing colons, quotes)
-2. Validate YAML with: yamllint config.yaml
+2. Validate YAML with: yamllint .fractary/config.yaml
 3. Restore from backup if available
 ```
 
@@ -185,11 +185,10 @@ if not validate(config):
 # BAD: Hardcoded path
 config_path = "/home/user/.config/app/config.yaml"
 
-# GOOD: Configurable with defaults
-config_paths = [
-    ".fractary/faber/config.yaml",
-    ".fractary/plugins/faber/config.yaml"
-]
+# GOOD: Use unified config location
+unified_config = ".fractary/config.yaml"  # All plugins share this file
+# FABER settings go in the 'faber:' section
+# Workflows go in '.fractary/faber/workflows/'
 ```
 
 ## Security Considerations

--- a/plugins/faber/skills/faber-config/scripts/merge-workflows.sh
+++ b/plugins/faber/skills/faber-config/scripts/merge-workflows.sh
@@ -92,7 +92,7 @@ resolve_workflow_path() {
             echo "${MARKETPLACE_ROOT}/fractary-codex/plugins/codex/config/workflows/${workflow_name}.json"
             ;;
         "project"|"")
-            echo "${PROJECT_ROOT}/.fractary/plugins/faber/workflows/${workflow_name}.json"
+            echo "${PROJECT_ROOT}/.fractary/faber/workflows/${workflow_name}.json"
             ;;
         *)
             # Fallback to old unified marketplace for backward compatibility


### PR DESCRIPTION
## Summary

This PR aligns workflow path configuration across all FABER components, removing legacy paths and establishing `.fractary/faber/workflows/` as the canonical location for project workflows.

**BREAKING CHANGE**: The legacy path `.fractary/plugins/faber/workflows/` is no longer supported.

## Changes

### Core Changes
- **Configurator agent** (`configurator.md`): Rewritten to write `faber:` section in unified `.fractary/config.yaml` instead of standalone `.fractary/faber/config.yaml`
- **CLI config manager** (`cli/src/lib/config.ts`): Removed legacy fallback logic that checked `.fractary/plugins/faber/workflows/`
- **merge-workflows.sh**: Updated project namespace resolution to `.fractary/faber/workflows/`
- **config.schema.json**: Updated default project namespace path example

### Documentation Updates
- `plugins/faber/docs/configuration.md`: Updated all path references
- `plugins/faber/docs/PROJECT-INTEGRATION-GUIDE.md`: Updated initialization and workflow customization examples
- `plugins/faber/config/workflows/README.md`: Updated workflow configuration examples
- `plugins/faber/skills/faber-config/SKILL.md`: Updated all documentation
- `plugins/faber/skills/agent-type-configurator/SKILL.md` and `standards.md`: Updated examples

### Version Updates
- CLI (@fractary/faber-cli): 1.5.0 → 1.5.1 (patch)
- faber plugin: 3.6.0 → 3.6.1 (patch)

## Test Plan

- [ ] Run `/fractary-faber:configure` in a fresh project and verify `.fractary/config.yaml` contains `faber:` section with `workflow.config_path: ".fractary/faber/workflows"`
- [ ] Verify NO `.fractary/faber/config.yaml` file is created
- [ ] Create a test workflow at `.fractary/faber/workflows/test.json`
- [ ] Run merge-workflows.sh with `project:test` and verify it resolves to `.fractary/faber/workflows/test.json`
- [ ] Run `/fractary-faber:audit` and verify no path errors
- [ ] Test with existing projects to verify migration path
- [ ] Verify documentation examples work as written

🤖 Generated with [Claude Code](https://claude.com/claude-code)