### PR TITLE
Rename audit commands to workflow-specific naming

### DIFF
--- a/plugins/faber/IMPLEMENTATION-160.md
+++ b/plugins/faber/IMPLEMENTATION-160.md
@@ -149,8 +149,8 @@ This document summarizes the implementation of FABER v2.0 core infrastructure, c
    - `phase-validate.sh` - Validate phase configuration
    - `workflow-validate.sh` - Validate complete workflow (supports --all)
 
-2. **Audit Scripts** (2 files):
-   - `workflow-audit.sh` - Completeness scoring (100 point scale)
+2. **Inspect Scripts** (2 files):
+   - `workflow-inspect.sh` - Completeness scoring (100 point scale)
      - 6 scoring categories:
        1. Basic Configuration (20pts)
        2. Phase Configuration (40pts)
@@ -429,9 +429,9 @@ All functionality is accessed via core scripts:
 ./skills/core/scripts/diagnostics.sh --verbose
 ```
 
-**Audit Workflow**:
+**Inspect Workflow**:
 ```bash
-./skills/core/scripts/workflow-audit.sh default --verbose
+./skills/core/scripts/workflow-inspect.sh default --verbose
 ```
 
 **Get Recommendations**:

--- a/plugins/faber/agents/agent-engineer.md
+++ b/plugins/faber/agents/agent-engineer.md
@@ -35,7 +35,7 @@ You are the **Agent Engineer**, responsible for creating new FABER-compliant age
 - "Build an agent to audit code quality"
 - "Update the spec-generator to support new templates"
 - "Add parallel processing to the faber-planner agent"
-- "Fix the error handling in workflow-auditor"
+- "Fix the error handling in workflow-inspector"
 - "Improve the documentation agent's output format"
 
 Your job is to:
@@ -111,7 +111,7 @@ api-documenter --mode create --purpose "Generates API documentation" --context "
 faber-planner --mode update --context "Add support for parallel step execution"
 
 # UPDATE: Change model and tools
-workflow-auditor --mode update --model opus --tools "Read,Write,Glob,Grep,Bash"
+workflow-inspector --mode update --model opus --tools "Read,Write,Glob,Grep,Bash"
 
 # UPDATE: Refine workflow steps
 spec-generator --mode update --context "Improve error handling in Step 3 to catch missing template files"
@@ -699,7 +699,7 @@ faber-planner --mode update --context "Add support for conditional step executio
 
 **Input:**
 ```bash
-workflow-auditor --mode update --model opus --tools "Read,Write,Glob,Grep,Bash,AskUserQuestion"
+workflow-inspector --mode update --model opus --tools "Read,Write,Glob,Grep,Bash,AskUserQuestion"
 ```
 
 **Output:**

--- a/plugins/faber/agents/agent-inspector.md
+++ b/plugins/faber/agents/agent-inspector.md
@@ -767,12 +767,12 @@ Includes additional checks based on the provided context about security validati
 
 - Run before merging new agents
 - Include in CI/CD pipeline
-- Use with workflow-audit for complete project validation
+- Use with workflow-inspect for complete project validation
 
 ## See Also
 
 - `/fractary-faber:agent-create` - Create new agents
-- `/fractary-faber:workflow-audit` - Audit workflow configuration (project-wide status)
+- `/fractary-faber:workflow-inspect` - Audit workflow configuration (project-wide status)
 - `plugins/faber/docs/FABER-AGENT-BEST-PRACTICES.md` - Complete best practices guide
 
 </NOTES>

--- a/plugins/faber/agents/configurator.md
+++ b/plugins/faber/agents/configurator.md
@@ -1058,7 +1058,7 @@ Human-readable output with progress indicators and guidance.
 <RELATED_COMMANDS>
 ## Related Commands
 
-- `/fractary-faber:workflow-audit` - Validate configuration
+- `/fractary-faber:workflow-inspect` - Validate configuration
 - `/fractary-faber:workflow-status` - Show current status
 - `/fractary-faber:workflow-plan` - Plan a workflow
 - `/fractary-faber-cloud:configure` - Configure cloud infrastructure

--- a/plugins/faber/agents/workflow-engineer.md
+++ b/plugins/faber/agents/workflow-engineer.md
@@ -391,7 +391,7 @@ When generating steps for a phase, consider the context provided and the selecte
    - Options: "Yes, run audit (Recommended)", "No, I'm done"
 
 6. If validation is requested, display the command to run:
-   - `/fractary-faber:workflow-audit {output_path}`
+   - `/fractary-faber:workflow-inspect {output_path}`
 
 ## Exit Codes
 
@@ -428,7 +428,7 @@ The workflow engineer ensures all workflows follow these best practices:
 - **Commands**:
   - `commands/workflow-create.md` - Create new workflows
   - `commands/workflow-update.md` - Update existing workflows
-  - `commands/workflow-audit.md` - Validate workflow configuration
+  - `commands/workflow-inspect.md` - Validate workflow configuration
   - `commands/workflow-run.md` - Execute workflows
 - **Workflows**:
   - `config/workflows/core.json` - Core workflow to extend

--- a/plugins/faber/agents/workflow-status.md
+++ b/plugins/faber/agents/workflow-status.md
@@ -606,7 +606,7 @@ watch -n 10 "/fractary-faber:workflow-status --timing"
 
 - **Commands**:
   - `commands/workflow-run.md` - Start/resume workflows
-  - `commands/workflow-audit.md` - Validate configuration
+  - `commands/workflow-inspect.md` - Validate configuration
 - **State Management**:
   - `docs/STATE-MANAGEMENT.md` - State file structure
   - `config/schema/state.schema.json` - State schema

--- a/plugins/faber/commands/agent-inspect.md
+++ b/plugins/faber/commands/agent-inspect.md
@@ -94,5 +94,5 @@ Returns inspection report with:
 ## See Also
 
 - `/fractary-faber:agent-create` - Create new FABER-compliant agents
-- `/fractary-faber:workflow-audit` - Audit workflow configuration (project-wide)
+- `/fractary-faber:workflow-inspect` - Inspect workflow configuration
 - `plugins/faber/docs/FABER-AGENT-BEST-PRACTICES.md` - Agent standards

--- a/plugins/faber/commands/agent-update.md
+++ b/plugins/faber/commands/agent-update.md
@@ -34,7 +34,7 @@ Use **Task** tool with `fractary-faber:agent-engineer` agent in **update mode** 
 /fractary-faber:agent-update faber-planner --context "Add support for parallel step execution"
 
 # Update model and tools
-/fractary-faber:agent-update workflow-auditor --model opus --tools "Read,Write,Glob,Grep,Bash"
+/fractary-faber:agent-update workflow-inspector --model opus --tools "Read,Write,Glob,Grep,Bash"
 
 # Update purpose/description
 /fractary-faber:agent-update spec-generator --purpose "Generates comprehensive technical specifications with architecture diagrams"

--- a/plugins/faber/commands/workflow-inspect.md
+++ b/plugins/faber/commands/workflow-inspect.md
@@ -1,12 +1,12 @@
 ---
-name: fractary-faber:workflow-audit
-description: Validate FABER workflow configuration - delegates to fractary-faber:workflow-auditor agent
-allowed-tools: Task(fractary-faber:workflow-auditor)
+name: fractary-faber:workflow-inspect
+description: Validate FABER workflow configuration - delegates to fractary-faber:workflow-inspector agent
+allowed-tools: Task(fractary-faber:workflow-inspector)
 model: claude-haiku-4-5
 argument-hint: '[<workflow-name-or-path>] [--verbose] [--fix] [--check <aspect>] [--config-path <path>]'
 ---
 
-Use **Task** tool with `fractary-faber:workflow-auditor` agent to validate workflow configuration with provided arguments.
+Use **Task** tool with `fractary-faber:workflow-inspector` agent to validate workflow configuration with provided arguments.
 
 **Workflow identifier** (optional):
 - `workflow-id` - Validates workflow from project config
@@ -16,8 +16,8 @@ Use **Task** tool with `fractary-faber:workflow-auditor` agent to validate workf
 
 ```
 Task(
-  subagent_type="fractary-faber:workflow-auditor",
+  subagent_type="fractary-faber:workflow-inspector",
   description="Validate FABER workflow configuration",
-  prompt="Audit workflow configuration: $ARGUMENTS"
+  prompt="Inspect workflow configuration: $ARGUMENTS"
 )
 ```

--- a/plugins/faber/skills/agent-type-project-auditor/SKILL.md
+++ b/plugins/faber/skills/agent-type-project-auditor/SKILL.md
@@ -156,11 +156,11 @@ Support filtering options:
 
 <EXAMPLES>
 
-## Example 1: workflow-auditor
+## Example 1: workflow-inspector
 
-The `workflow-auditor` agent validates all FABER workflows:
+The `workflow-inspector` agent validates all FABER workflows:
 
-**Location**: `plugins/faber/agents/workflow-auditor.md`
+**Location**: `plugins/faber/agents/workflow-inspector.md`
 
 **Key features:**
 - Validates ALL workflow configurations

--- a/plugins/faber/skills/agent-type-project-auditor/agent-config.json
+++ b/plugins/faber/skills/agent-type-project-auditor/agent-config.json
@@ -26,7 +26,7 @@
       "System-wide compliance checking"
     ],
     "examples": [
-      "workflow-auditor",
+      "workflow-inspector",
       "system-health-auditor",
       "compliance-auditor"
     ]

--- a/plugins/faber/skills/agent-type-project-auditor/standards.md
+++ b/plugins/faber/skills/agent-type-project-auditor/standards.md
@@ -177,4 +177,4 @@ highlight_warnings(filter(entities, has_warning))
 
 See these auditor agents for reference:
 
-- `plugins/faber/agents/workflow-auditor.md` - Workflow validation auditor
+- `plugins/faber/agents/workflow-inspector.md` - Workflow validation inspector

--- a/plugins/faber/skills/agent-type-selector/SKILL.md
+++ b/plugins/faber/skills/agent-type-selector/SKILL.md
@@ -212,7 +212,7 @@ Direct the user to the appropriate agent-type-* skill for:
 - Creates summary dashboards
 - Aggregates health and status information
 - **Typical tools**: Read, Glob, Grep, Bash, Skill
-- **Example**: `workflow-auditor` - Validates across all workflows
+- **Example**: `workflow-inspector` - Validates across all workflows
 
 </TYPE_DETAILS>
 

--- a/plugins/faber/skills/core/scripts/workflow-inspect.sh
+++ b/plugins/faber/skills/core/scripts/workflow-inspect.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #
-# workflow-audit.sh - Audit workflow completeness with scoring
+# workflow-inspect.sh - Inspect workflow completeness with scoring
 #
 # Usage:
-#   workflow-audit.sh [workflow-id]
-#   workflow-audit.sh --verbose
+#   workflow-inspect.sh [workflow-id]
+#   workflow-inspect.sh --verbose
 #
 # Example:
-#   workflow-audit.sh default
-#   workflow-audit.sh default --verbose
+#   workflow-inspect.sh default
+#   workflow-inspect.sh default --verbose
 
 set -euo pipefail
 
@@ -56,7 +56,7 @@ if [ -z "$WORKFLOW" ]; then
 fi
 
 echo -e "${BLUE}═══════════════════════════════════════${NC}"
-echo -e "${BLUE}  FABER Workflow Audit${NC}"
+echo -e "${BLUE}  FABER Workflow Inspection${NC}"
 echo -e "${BLUE}  Workflow: $WORKFLOW_ID${NC}"
 echo -e "${BLUE}═══════════════════════════════════════${NC}"
 echo ""

--- a/plugins/faber/skills/core/scripts/workflow-recommend.sh
+++ b/plugins/faber/skills/core/scripts/workflow-recommend.sh
@@ -238,7 +238,7 @@ if [ ${#PRIORITY_RECOMMENDATIONS[@]} -gt 3 ]; then
     echo ""
 fi
 
-echo "For detailed analysis, run: workflow-audit.sh $WORKFLOW_ID --verbose"
+echo "For detailed analysis, run: workflow-inspect.sh $WORKFLOW_ID --verbose"
 echo ""
 
 exit 0

--- a/plugins/faber/tests/integration/workflow-inspector.test.md
+++ b/plugins/faber/tests/integration/workflow-inspector.test.md
@@ -1,6 +1,6 @@
-# Workflow Auditor Integration Tests
+# Workflow Inspector Integration Tests
 
-This document defines integration test scenarios for the workflow-auditor agent enhancements.
+This document defines integration test scenarios for the workflow-inspector agent enhancements.
 
 ## Test Categories
 
@@ -14,7 +14,7 @@ This document defines integration test scenarios for the workflow-auditor agent 
 
 ## Test 1: No Argument Mode - Show Usage and List Workflows
 
-**Scenario**: User runs workflow-audit with no arguments
+**Scenario**: User runs workflow-inspect with no arguments
 
 **Setup**:
 ```bash
@@ -30,14 +30,14 @@ ls .fractary/faber/config.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit
+/fractary-faber:workflow-inspect
 
 # Expected output:
 # 🔍 FABER Workflow Audit
 # Target: Show usage and list available workflows
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #
-# Usage: /fractary-faber:workflow-audit [<workflow>] [OPTIONS]
+# Usage: /fractary-faber:workflow-inspect [<workflow>] [OPTIONS]
 #
 # Workflow identifier:
 #   workflow-id          Validate workflow from project config
@@ -73,7 +73,7 @@ grep -q '"id": "default"' .fractary/faber/config.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default
+/fractary-faber:workflow-inspect default
 
 # Expected output includes:
 # 🔍 FABER Workflow Audit
@@ -120,7 +120,7 @@ ls plugins/faber/config/workflows/feature.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit plugins/faber/config/workflows/feature.json
+/fractary-faber:workflow-inspect plugins/faber/config/workflows/feature.json
 
 # Expected output:
 # 🔍 FABER Workflow Audit
@@ -152,7 +152,7 @@ ls plugins/faber/config/workflows/default.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit fractary-faber:default
+/fractary-faber:workflow-inspect fractary-faber:default
 
 # Expected output:
 # 🔍 FABER Workflow Audit
@@ -183,7 +183,7 @@ ls .fractary/faber/config.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit nonexistent
+/fractary-faber:workflow-inspect nonexistent
 
 # Expected output:
 # ❌ ERROR: Workflow 'nonexistent' not found in config
@@ -208,7 +208,7 @@ ls .fractary/faber/config.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit ./nonexistent.json
+/fractary-faber:workflow-inspect ./nonexistent.json
 
 # Expected output:
 # ❌ ERROR: Workflow file not found: ./nonexistent.json
@@ -234,7 +234,7 @@ echo '{"invalid": json}' > /tmp/invalid-workflow.json
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit /tmp/invalid-workflow.json
+/fractary-faber:workflow-inspect /tmp/invalid-workflow.json
 
 # Expected output:
 # ❌ ERROR: File is not a valid workflow (missing required fields: id, phases)
@@ -264,13 +264,13 @@ ls plugins/faber/skills/*/SKILL.md | wc -l  # Should be > 0
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default --verbose
+/fractary-faber:workflow-inspect default --verbose
 
 # Expected output includes:
 # 🔍 Discovering agents and skills...
 # Found N agents/skills in registry
 # Registry entries:
-#   - fractary-faber:workflow-auditor (agent, faber)
+#   - fractary-faber:workflow-inspector (agent, faber)
 #   - fractary-faber:faber-planner (agent, faber)
 #   - fractary-spec:spec-create (skill, spec)
 #   ...
@@ -299,7 +299,7 @@ cat plugins/faber/config/workflows/default.json | grep -E "(Skill|Task|/)"
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default --verbose
+/fractary-faber:workflow-inspect default --verbose
 
 # Expected output includes:
 # Extracting agent/skill references from workflow steps...
@@ -344,7 +344,7 @@ EOF
 ```bash
 # Create workflow referencing test agent
 # Run audit
-/fractary-faber:workflow-audit test-workflow --verbose
+/fractary-faber:workflow-inspect test-workflow --verbose
 
 # Expected output includes:
 # ✅ COMPLIANT (1)
@@ -384,7 +384,7 @@ EOF
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit test-workflow --verbose
+/fractary-faber:workflow-inspect test-workflow --verbose
 
 # Expected output includes:
 # ⚠️  UNKNOWN (1)
@@ -422,7 +422,7 @@ rm -rf .claude/agents/test-unknown.md
 **Verification**:
 ```bash
 # Audit workflow that references "fractary-typo:missing"
-/fractary-faber:workflow-audit workflow-with-typo
+/fractary-faber:workflow-inspect workflow-with-typo
 
 # Expected output includes:
 # ❌ NOT FOUND (1)
@@ -475,7 +475,7 @@ EOF
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit test-workflow --verbose
+/fractary-faber:workflow-inspect test-workflow --verbose
 
 # Expected output includes:
 # ✅ COMPLIANT (1)
@@ -502,7 +502,7 @@ rm -rf .claude/agents/test-implicit.md
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default --verbose
+/fractary-faber:workflow-inspect default --verbose
 
 # Expected output includes:
 # Mode: workflow_id
@@ -512,7 +512,7 @@ rm -rf .claude/agents/test-implicit.md
 # 🔍 Discovering agents and skills...
 # Found 50 agents/skills in registry
 # Registry entries:
-#   - fractary-faber:workflow-auditor (agent, faber)
+#   - fractary-faber:workflow-inspector (agent, faber)
 #   [... full list ...]
 #
 # Extracting agent/skill references from workflow steps...
@@ -537,7 +537,7 @@ rm -rf .claude/agents/test-implicit.md
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default --check steps
+/fractary-faber:workflow-inspect default --check steps
 
 # Expected output:
 # - Should include agent/skill validation
@@ -565,7 +565,7 @@ rm -rf .claude/agents/test-implicit.md
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default --fix
+/fractary-faber:workflow-inspect default --fix
 
 # Expected output includes:
 # ✓ Auto-fixed N issues
@@ -583,7 +583,7 @@ rm -rf .claude/agents/test-implicit.md
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit default
+/fractary-faber:workflow-inspect default
 echo $?
 
 # Expected: 0
@@ -601,7 +601,7 @@ echo $?
 **Verification**:
 ```bash
 # Audit workflow with warnings (e.g., missing descriptions)
-/fractary-faber:workflow-audit workflow-with-warnings
+/fractary-faber:workflow-inspect workflow-with-warnings
 echo $?
 
 # Expected: 1
@@ -619,7 +619,7 @@ echo $?
 **Verification**:
 ```bash
 # Audit workflow with errors (e.g., missing required phase)
-/fractary-faber:workflow-audit workflow-with-errors
+/fractary-faber:workflow-inspect workflow-with-errors
 echo $?
 
 # Expected: 2
@@ -636,7 +636,7 @@ echo $?
 
 **Verification**:
 ```bash
-/fractary-faber:workflow-audit nonexistent
+/fractary-faber:workflow-inspect nonexistent
 echo $?
 
 # Expected: 3
@@ -670,13 +670,13 @@ Run each test scenario individually following the verification steps.
 
 ```bash
 # Run all tests
-./plugins/faber/tests/integration/run-workflow-auditor-tests.sh
+./plugins/faber/tests/integration/run-workflow-inspector-tests.sh
 
 # Run specific category
-./plugins/faber/tests/integration/run-workflow-auditor-tests.sh argument-parsing
+./plugins/faber/tests/integration/run-workflow-inspector-tests.sh argument-parsing
 
 # Run specific test
-./plugins/faber/tests/integration/run-workflow-auditor-tests.sh test-1
+./plugins/faber/tests/integration/run-workflow-inspector-tests.sh test-1
 ```
 
 ## Success Criteria


### PR DESCRIPTION
…tor to workflow-inspector

This follows the same pattern as the agent-audit rename (commit 0eb63bc), reserving "audit" terminology for project-wide auditing and using "inspect" for single entity inspection.

Changes:
- Rename workflow-audit.md command to workflow-inspect.md
- Rename workflow-auditor.md agent to workflow-inspector.md
- Rename workflow-audit.sh script to workflow-inspect.sh
- Rename workflow-auditor.test.md to workflow-inspector.test.md
- Update all cross-references in documentation and related files