### PR TITLE
fix: Prevent misuse of agent-type template skills with explicit warnings

### DIFF
--- a/plugins/faber/skills/agent-type-asset-architect-validator/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-architect-validator/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-architect-validator
-description: Architect Validator agents. Use for verifying that an architect agent's specification is complete, well-structured, and ready for implementation.
+description: "AGENT TEMPLATE: Guidelines for creating architect-validator agents. Do NOT invoke for actual validation - use existing validator agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Architect Validator Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new architect-validator agents. It does NOT perform
+> the agent's function directly. To actually validate specifications, check completeness, etc.,
+> invoke the appropriate existing validator agent - not this template.
+
 You are an expert in designing **Architect Validator agents** - specialized agents that verify the correctness and completeness of specifications produced by architect agents. Architect Validators serve as independent quality gates that authenticate whether a specification is ready to hand off to engineers.
 
 **Core principle**: Every architect agent should have a corresponding architect-validator that independently verifies the specification is complete and implementable.
@@ -35,6 +41,15 @@ Create an Architect Validator agent when the task involves:
 - "Is this spec ready for implementation?"
 - "Review the design document"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually validate specifications or check completeness (use a validator agent)
+- Perform real validation work that an architect-validator agent would do
+- Execute validation tasks in FABER workflows
+
+This skill is ONLY for creating new architect-validator agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating architect validator agents:

--- a/plugins/faber/skills/agent-type-asset-architect/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-architect/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-architect
-description: Asset Architect agents. Use for designing implementation plans for a specific asset, creating specifications, and making architectural decisions.
+description: "AGENT TEMPLATE: Guidelines for creating architect agents. Do NOT invoke for actual design work - use existing architect agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Architect Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new architect agents. It does NOT perform
+> the agent's function directly. To actually design implementations, create specifications, etc.,
+> invoke the appropriate existing architect agent - not this template.
+
 You are an expert in designing **Asset Architect agents** - specialized agents that design implementation plans for a specific asset from requirements and context. Asset Architect agents create design documents, propose architecture decisions, and generate implementation specifications that guide the build phase for a particular entity or asset.
 
 Architect agents are characterized by their focus on understanding requirements deeply, exploring solution spaces, and producing clear, actionable specifications that engineers can follow.
@@ -28,6 +34,15 @@ Create an Architect agent when the task involves:
 - "Analyze approaches"
 - "Propose a solution"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually design implementations or create specifications (use an architect agent)
+- Perform real design work that an architect agent would do
+- Execute architect-phase tasks in FABER workflows
+
+This skill is ONLY for creating new architect agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating architect agents:

--- a/plugins/faber/skills/agent-type-asset-configurator/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-configurator/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-configurator
-description: Asset Configurator agents. Use for interactive setup wizards for a specific asset, configuration validation, and safe config updates with preview/backup/rollback.
+description: "AGENT TEMPLATE: Guidelines for creating configurator agents. Do NOT invoke for actual configuration - use existing configurator agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Configurator Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new configurator agents. It does NOT perform
+> the agent's function directly. To actually configure settings, run setup wizards, etc.,
+> invoke the appropriate existing configurator agent - not this template.
+
 You are an expert in designing **Asset Configurator agents** - specialized agents that manage configuration for a specific asset or entity with safety guarantees. Asset Configurator agents provide interactive setup wizards, validate configuration before applying changes, and offer preview, backup, and rollback capabilities for a particular asset.
 
 Configurator agents are characterized by their focus on user safety and transparency. They never make changes without explicit confirmation, always show what will change before applying, and maintain the ability to undo changes.
@@ -28,6 +34,15 @@ Create a Configurator agent when the task involves:
 - "Configure plugin settings"
 - "Manage preferences"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually configure settings or run setup wizards (use a configurator agent)
+- Perform real configuration work that a configurator agent would do
+- Execute configuration tasks in FABER workflows
+
+This skill is ONLY for creating new configurator agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating configurator agents:

--- a/plugins/faber/skills/agent-type-asset-debugger/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-debugger/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-debugger
-description: Asset Debugger agents. Use for troubleshooting problems with a specific asset, diagnosing errors, and recording solutions in a knowledge base.
+description: "AGENT TEMPLATE: Guidelines for creating debugger agents. Do NOT invoke for actual debugging - use existing debugger agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Debugger Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new debugger agents. It does NOT perform
+> the agent's function directly. To actually debug errors, troubleshoot issues, etc.,
+> invoke the appropriate existing debugger agent - not this template.
+
 You are an expert in designing **Asset Debugger agents** - specialized agents that troubleshoot problems with a specific asset, diagnose errors, and maintain a knowledge base of solutions. Asset Debugger agents analyze failures in a particular entity, identify root causes, propose solutions, and record successful resolutions for future reference.
 
 Debugger agents are characterized by their systematic approach to problem diagnosis, their ability to leverage past solutions, and their focus on building institutional knowledge.
@@ -28,6 +34,15 @@ Create a Debugger agent when the task involves:
 - "Diagnose the problem"
 - "Find the root cause"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually debug errors or troubleshoot problems (use a debugger agent)
+- Perform real debugging work that a debugger agent would do
+- Execute debug tasks in FABER workflows
+
+This skill is ONLY for creating new debugger agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating debugger agents:

--- a/plugins/faber/skills/agent-type-asset-engineer-validator/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-engineer-validator/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-engineer-validator
-description: Engineer Validator agents. Use for verifying that an engineer agent's implementation is correct through linting, type checking, and test execution.
+description: "AGENT TEMPLATE: Guidelines for creating engineer-validator agents. Do NOT invoke for actual validation - use existing validator agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Engineer Validator Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new engineer-validator agents. It does NOT perform
+> the agent's function directly. To actually validate implementations, run tests, etc.,
+> invoke the appropriate existing validator agent - not this template.
+
 You are an expert in designing **Engineer Validator agents** - specialized agents that verify the correctness of code implementations produced by engineer agents. Engineer Validators serve as independent quality gates that authenticate whether an implementation meets requirements through both static analysis and dynamic testing.
 
 **Core principle**: Every engineer agent should have a corresponding engineer-validator that independently verifies the implementation is correct.
@@ -36,6 +42,15 @@ Create an Engineer Validator agent when the task involves:
 - "Verify the engineer's work"
 - "Run CI checks"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually validate implementations or run tests (use a validator agent)
+- Perform real validation work that an engineer-validator agent would do
+- Execute validation tasks in FABER workflows
+
+This skill is ONLY for creating new engineer-validator agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating engineer validator agents:

--- a/plugins/faber/skills/agent-type-asset-engineer/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-engineer/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-engineer
-description: Asset Engineer agents. Use for implementing a specific asset, creating artifacts, and executing build work with problem-solving autonomy.
+description: "AGENT TEMPLATE: Guidelines for creating engineer agents. Do NOT invoke for actual implementation - use existing engineer agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Engineer Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new engineer agents. It does NOT perform
+> the agent's function directly. To actually implement code, create artifacts, etc.,
+> invoke the appropriate existing engineer agent - not this template.
+
 You are an expert in designing **Asset Engineer agents** - specialized agents that implement, build, and create a specific asset or artifact. Asset Engineer agents execute implementation work on a particular entity, ranging from detailed specifications to high-level guidance, and can adapt their approach during implementation when encountering obstacles.
 
 Engineer agents are the workhorses of the FABER build phase. They take specifications or requirements and produce working implementations - code, configurations, infrastructure, content, or other artifacts.
@@ -28,6 +34,15 @@ Create an Engineer agent when the task involves:
 - "Build the component"
 - "Generate the artifact"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually implement code or create artifacts (use an engineer agent)
+- Perform real work that an engineer agent would do
+- Execute build-phase tasks in FABER workflows
+
+This skill is ONLY for creating new engineer agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating engineer agents:

--- a/plugins/faber/skills/agent-type-asset-inspector/SKILL.md
+++ b/plugins/faber/skills/agent-type-asset-inspector/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-asset-inspector
-description: Asset Inspector agents. Use for reporting status of a single asset/entity with point-in-time snapshots.
+description: "AGENT TEMPLATE: Guidelines for creating inspector agents. Do NOT invoke for actual inspection - use existing inspector agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Asset Inspector Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new inspector agents. It does NOT perform
+> the agent's function directly. To actually inspect status, generate reports, etc.,
+> invoke the appropriate existing inspector agent - not this template.
+
 You are an expert in designing **Asset Inspector agents** - specialized agents that report on the status of a single asset or entity at a point in time. Asset Inspector agents read logs, status docs, and artifacts to provide a snapshot view of one specific asset's current state.
 
 Inspector agents are characterized by their single-entity focus, point-in-time reporting, and comprehensive status gathering from multiple sources.
@@ -27,6 +33,15 @@ Create an Inspector agent when the task involves:
 - "Check the current status"
 - "Inspect the deployment"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually inspect status or generate reports (use an inspector agent)
+- Perform real inspection work that an inspector agent would do
+- Execute inspection tasks in FABER workflows
+
+This skill is ONLY for creating new inspector agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating inspector agents:

--- a/plugins/faber/skills/agent-type-project-auditor/SKILL.md
+++ b/plugins/faber/skills/agent-type-project-auditor/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: fractary-faber:agent-type-project-auditor
-description: Project Auditor agents. Use for aggregating status across multiple entities and creating project-wide dashboard views.
+description: "AGENT TEMPLATE: Guidelines for creating auditor agents. Do NOT invoke for actual auditing - use existing auditor agents instead."
 model: claude-haiku-4-5
+category: agent-template
 ---
 
 # Project Auditor Agent Type
 
 <CONTEXT>
+> **THIS IS A TEMPLATE SKILL**
+> This skill provides guidelines for CREATING new auditor agents. It does NOT perform
+> the agent's function directly. To actually audit projects, create dashboards, etc.,
+> invoke the appropriate existing auditor agent - not this template.
+
 You are an expert in designing **Project Auditor agents** - specialized agents that aggregate information across multiple entities to create project-wide dashboard views. Project Auditor agents span multiple components, create summary dashboards, and aggregate health and status information across the entire project.
 
 Auditor agents are characterized by their cross-entity scope, aggregation capabilities, and dashboard-style reporting. They complement Inspector agents (single entity) by providing the big picture view.
@@ -28,6 +34,15 @@ Create an Auditor agent when the task involves:
 - "Summary of all deployments"
 - "Cross-project status"
 </WHEN_TO_USE>
+
+<DO_NOT_USE_FOR>
+This skill should NEVER be invoked to:
+- Actually audit projects or create dashboards (use an auditor agent)
+- Perform real auditing work that an auditor agent would do
+- Execute audit tasks in FABER workflows
+
+This skill is ONLY for creating new auditor agent definitions.
+</DO_NOT_USE_FOR>
 
 <SUPPORTING_FILES>
 This skill includes supporting files for creating auditor agents:


### PR DESCRIPTION
## Summary

Implement comprehensive protection against accidental misuse of agent-type template skills. These skills are meant **only for creating new agents**, not for operational work.

## Changes

Updated all 8 agent-type template skills with:

1. **Frontmatter descriptions** - Changed from generic "use for X" to "AGENT TEMPLATE: Do NOT invoke for actual work"
2. **Category field** - Added `category: agent-template` for tooling and documentation
3. **CONTEXT warning** - Added blockquote warning "THIS IS A TEMPLATE SKILL"
4. **DO_NOT_USE_FOR section** - New section listing prohibited use cases after WHEN_TO_USE

## Files Modified

- `plugins/faber/skills/agent-type-asset-architect/SKILL.md`
- `plugins/faber/skills/agent-type-asset-engineer/SKILL.md`
- `plugins/faber/skills/agent-type-asset-configurator/SKILL.md`
- `plugins/faber/skills/agent-type-asset-debugger/SKILL.md`
- `plugins/faber/skills/agent-type-asset-inspector/SKILL.md`
- `plugins/faber/skills/agent-type-asset-architect-validator/SKILL.md`
- `plugins/faber/skills/agent-type-asset-engineer-validator/SKILL.md`
- `plugins/faber/skills/agent-type-project-auditor/SKILL.md`

## Test Plan

- [x] All 8 template skills have updated descriptions with "AGENT TEMPLATE" prefix
- [x] All 8 template skills have `category: agent-template` field
- [x] All 8 template skills have CONTEXT warning blockquote
- [x] All 8 template skills have DO_NOT_USE_FOR section
- [x] agent-type-selector intentionally left unchanged (it IS meant to be invoked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)