### PR TITLE
chore: bump opencode plugin version to 1.0.1

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@fractary/opencode-faber",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./plugins/fractary-faber.js",
-  "keywords": ["opencode-plugin", "fractary", "faber"],
+  "keywords": [
+    "opencode-plugin",
+    "fractary",
+    "faber"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/fractary/faber",


### PR DESCRIPTION
## Summary
- Bump @fractary/opencode-faber version from 1.0.0 to 1.0.1
- Format keywords array for consistency