### PR TITLE
fix(resolver): surface middle-layer steps in multi-tier inheritance

### DIFF
--- a/plugins/faber/skills/fractary-faber-faber-config/scripts/merge-workflows.sh
+++ b/plugins/faber/skills/fractary-faber-faber-config/scripts/merge-workflows.sh
@@ -405,15 +405,26 @@ merge_phase_steps() {
         merged_steps=$(echo "$merged_steps" "$pre_steps" | jq -s '.[0] + .[1]')
     done
 
-    # Main steps: only from child (index 0)
-    local child_id
-    child_id=$(echo "$chain_json" | jq -r '.[0]')
-    local child_workflow
-    child_workflow=$(load_workflow "$child_id")
-    local main_steps
-    main_steps=$(echo "$child_workflow" | jq --arg phase "$phase" '.phases[$phase].steps // []')
-    main_steps=$(echo "$main_steps" | jq --arg src "$child_id" '[.[] | . + {"source": $src, "position": "step"}]')
-    merged_steps=$(echo "$merged_steps" "$main_steps" | jq -s '.[0] + .[1]')
+    # Main steps: nearest ancestor that defines `steps` wins
+    # (child > parent > grandparent). Child still shadows ancestors when it
+    # declares its own steps; otherwise middle-layer plugin steps are
+    # correctly surfaced. Matches sdk/js/src/workflow/resolver.ts.
+    for ((i=0; i<chain_length; i++)); do
+        local workflow_id
+        workflow_id=$(echo "$chain_json" | jq -r ".[$i]")
+        local workflow_json
+        workflow_json=$(load_workflow "$workflow_id")
+        # has_steps is true when phases[phase].steps is defined (array, possibly empty)
+        local has_steps
+        has_steps=$(echo "$workflow_json" | jq --arg phase "$phase" '.phases[$phase].steps != null')
+        if [[ "$has_steps" == "true" ]]; then
+            local main_steps
+            main_steps=$(echo "$workflow_json" | jq --arg phase "$phase" '.phases[$phase].steps')
+            main_steps=$(echo "$main_steps" | jq --arg src "$workflow_id" '[.[] | . + {"source": $src, "position": "step"}]')
+            merged_steps=$(echo "$merged_steps" "$main_steps" | jq -s '.[0] + .[1]')
+            break
+        fi
+    done
 
     # Post-steps: iterate from child (first) to root (last) = chain order
     for ((i=0; i<chain_length; i++)); do

--- a/sdk/js/src/workflow/__tests__/resolver.test.ts
+++ b/sdk/js/src/workflow/__tests__/resolver.test.ts
@@ -919,4 +919,139 @@ describe('WorkflowResolver', () => {
       expect(resolved.phases.architect.enabled).toBe(true);
     });
   });
+
+  describe('Main Steps Inheritance', () => {
+    it('should use child steps when child defines them (shadows ancestors)', async () => {
+      createWorkflow('fractary-faber', 'parent-steps', {
+        id: 'parent-steps',
+        phases: {
+          evaluate: { steps: [{ id: 'parent-validate', name: 'Parent validate', prompt: 'parent' }] },
+        },
+      });
+
+      createWorkflow('project', 'child-overrides', {
+        id: 'child-overrides',
+        extends: 'faber@fractary-faber-parent-steps',
+        phases: {
+          evaluate: { steps: [{ id: 'child-validate', name: 'Child validate', prompt: 'child' }] },
+        },
+      });
+
+      const resolved = await resolver.resolveWorkflow('child-overrides');
+      const ids = resolved.phases.evaluate.steps.map((s) => s.id);
+
+      expect(ids).toEqual(['child-validate']);
+    });
+
+    it('should surface middle-layer steps when child is silent on that phase', async () => {
+      // 3-tier chain: project → middle → base
+      // Regression test for https://github.com/fractary/faber/issues/221
+      createWorkflow('fractary-faber', 'base', {
+        id: 'base',
+        phases: {
+          evaluate: { pre_steps: [{ id: 'base-pre', name: 'Base pre', prompt: 'base pre' }] },
+        },
+      });
+
+      createWorkflow('fractary-faber', 'middle', {
+        id: 'middle',
+        extends: 'faber@fractary-faber-base',
+        phases: {
+          evaluate: {
+            steps: [
+              { id: 'middle-execute', name: 'Middle execute', prompt: 'run domain operation' },
+              { id: 'middle-validate', name: 'Middle validate', prompt: 'validate domain result' },
+            ],
+          },
+        },
+      });
+
+      createWorkflow('project', 'project-extends-middle', {
+        id: 'project-extends-middle',
+        extends: 'faber@fractary-faber-middle',
+        phases: {
+          release: { steps: [{ id: 'project-deploy', name: 'Project deploy', prompt: 'deploy' }] },
+        },
+      });
+
+      const resolved = await resolver.resolveWorkflow('project-extends-middle');
+      const evaluateIds = resolved.phases.evaluate.steps.map((s) => s.id);
+
+      expect(evaluateIds).toContain('base-pre');
+      expect(evaluateIds).toContain('middle-execute');
+      expect(evaluateIds).toContain('middle-validate');
+    });
+
+    it('should surface base steps when both child and middle are silent', async () => {
+      createWorkflow('fractary-faber', 'base-with-steps', {
+        id: 'base-with-steps',
+        phases: {
+          evaluate: { steps: [{ id: 'base-step', name: 'Base step', prompt: 'base' }] },
+        },
+      });
+
+      createWorkflow('fractary-faber', 'middle-silent', {
+        id: 'middle-silent',
+        extends: 'faber@fractary-faber-base-with-steps',
+        // middle defines no evaluate phase at all
+      });
+
+      createWorkflow('project', 'project-silent', {
+        id: 'project-silent',
+        extends: 'faber@fractary-faber-middle-silent',
+      });
+
+      const resolved = await resolver.resolveWorkflow('project-silent');
+      const ids = resolved.phases.evaluate.steps.map((s) => s.id);
+
+      expect(ids).toEqual(['base-step']);
+    });
+
+    it('should treat explicit empty steps: [] as an opt-out (shadows ancestors)', async () => {
+      createWorkflow('fractary-faber', 'parent-with-steps', {
+        id: 'parent-with-steps',
+        phases: {
+          evaluate: { steps: [{ id: 'parent-step', name: 'Parent step', prompt: 'parent' }] },
+        },
+      });
+
+      createWorkflow('project', 'child-opts-out', {
+        id: 'child-opts-out',
+        extends: 'faber@fractary-faber-parent-with-steps',
+        phases: {
+          evaluate: { steps: [] },
+        },
+      });
+
+      const resolved = await resolver.resolveWorkflow('child-opts-out');
+      const ids = resolved.phases.evaluate.steps.map((s) => s.id);
+
+      expect(ids).toEqual([]);
+    });
+
+    it('should record the correct source for merged middle-layer steps', async () => {
+      createWorkflow('fractary-faber', 'src-base', {
+        id: 'src-base',
+        phases: { evaluate: { pre_steps: [{ id: 'b', name: 'b', prompt: 'b' }] } },
+      });
+
+      createWorkflow('fractary-faber', 'src-middle', {
+        id: 'src-middle',
+        extends: 'faber@fractary-faber-src-base',
+        phases: { evaluate: { steps: [{ id: 'm', name: 'm', prompt: 'm' }] } },
+      });
+
+      createWorkflow('project', 'src-child', {
+        id: 'src-child',
+        extends: 'faber@fractary-faber-src-middle',
+      });
+
+      const resolved = await resolver.resolveWorkflow('src-child');
+      const middleStep = resolved.phases.evaluate.steps.find((s) => s.id === 'm');
+
+      expect(middleStep).toBeDefined();
+      expect(middleStep?.source).toBe('faber@fractary-faber-src-middle');
+      expect(middleStep?.position).toBe('step');
+    });
+  });
 });

--- a/sdk/js/src/workflow/resolver.ts
+++ b/sdk/js/src/workflow/resolver.ts
@@ -514,13 +514,14 @@ async function validateUrlSecurity(url: string): Promise<void> {
  *
  * Merge algorithm (for each phase):
  * 1. Pre-steps: Root ancestor first (reversed chain order)
- * 2. Main steps: Only from child (first in chain)
+ * 2. Main steps: Nearest ancestor that defines `steps` wins
+ *    (child > parent > grandparent)
  * 3. Post-steps: Child first (chain order)
  *
  * Example for default → core:
  * - chain = ["default", "core"] (child first)
  * - pre_steps: core.pre_steps, then default.pre_steps
- * - steps: only default.steps
+ * - steps: default.steps if defined, otherwise core.steps
  * - post_steps: default.post_steps, then core.post_steps
  */
 export class WorkflowResolver {
@@ -1064,7 +1065,10 @@ export class WorkflowResolver {
    *
    * Order:
    * 1. Pre-steps: Root ancestor first (reversed chain - index n-1 to 0)
-   * 2. Main steps: Only from child (index 0)
+   * 2. Main steps: Nearest ancestor that defines `steps` wins
+   *    (child > parent > grandparent). The child still shadows ancestors
+   *    when it declares its own `steps`, but middle-layer plugin steps are
+   *    now correctly surfaced when the child is silent on this phase.
    * 3. Post-steps: Child first (chain order - index 0 to n-1)
    */
   private mergePhaseSteps(
@@ -1089,17 +1093,23 @@ export class WorkflowResolver {
       }
     }
 
-    // Main steps: only from child (index 0)
-    const childWorkflow = this.workflowCache.get(chain[0])!;
-    const childPhase = childWorkflow.phases?.[phaseName];
-    const mainSteps = childPhase?.steps || [];
-
-    for (const step of mainSteps) {
-      mergedSteps.push({
-        ...step,
-        source: chain[0],
-        position: 'step',
-      });
+    // Main steps: nearest ancestor that defines `steps` wins
+    // (child > parent > grandparent). A workflow with an explicit empty
+    // `steps: []` still shadows its ancestors, matching intent to opt out
+    // of inherited main steps.
+    for (const workflowId of chain) {
+      const workflow = this.workflowCache.get(workflowId)!;
+      const phase = workflow.phases?.[phaseName];
+      if (phase?.steps !== undefined) {
+        for (const step of phase.steps) {
+          mergedSteps.push({
+            ...step,
+            source: workflowId,
+            position: 'step',
+          });
+        }
+        break;
+      }
     }
 
     // Post-steps: iterate from child (first) to root (last) - chain order


### PR DESCRIPTION
Closes #221.

## Summary

`mergePhaseSteps` currently reads `phases.*.steps` only from `chain[0]`. In a 3-tier `extends` chain (project → plugin → base), the plugin's `steps` array is silently dropped — even when the child doesn't declare its own.

This PR walks the chain child-first and takes the nearest ancestor that defines `steps`. Child still shadows ancestors when it declares its own; explicit `steps: []` still opts out. Pre/post step semantics are unchanged.

## Behavior

| Scenario | Before | After |
|---|---|---|
| 2-tier, child defines steps | Child wins | Child wins (unchanged) |
| 2-tier, child silent | Empty | Parent steps surface |
| 3-tier, child defines steps | Child wins | Child wins (unchanged) |
| 3-tier, child silent, middle defines | **Empty (bug)** | Middle steps surface ✓ |
| 3-tier, all silent, base defines | Empty | Base steps surface |
| Child has `steps: []` | Empty | Empty (opt-out preserved) |

Matches the "child shadows" intent documented at `sdk/js/src/workflow/resolver.ts:513-525`, just correctly applied across the full chain instead of only `chain[0]`.

## Changes

- **`sdk/js/src/workflow/resolver.ts`** — rewrite the `steps` block of `mergePhaseSteps` to walk child-first and break on the first layer that defines `steps`. Class-level and method-level doc comments updated to match.
- **`plugins/faber/skills/fractary-faber-faber-config/scripts/merge-workflows.sh`** — same fix in the sibling bash resolver so both implementations stay consistent.
- **`sdk/js/src/workflow/__tests__/resolver.test.ts`** — 5 new tests under a new `Main Steps Inheritance` describe block covering:
  - child-shadows-ancestors when child defines `steps`
  - middle-layer steps surface when child is silent on that phase (regression for #221)
  - base-layer steps surface when both child and middle are silent
  - explicit `steps: []` opts out
  - `source` / `position` metadata recorded correctly on merged steps

## Verification

The existing Jest suite can't run on current `main` due to an unrelated `import.meta.url` TS compile issue in the current `jest.config.js` (`JavaScript SDK CI` is failing on `main` for the same reason). I verified the fix via a stand-alone node script that exercises the compiled `dist/` output:

```
$ node repro-middle-layer.mjs
inheritance_chain: [ 'project-extends-middle', 'middle', 'base' ]
evaluate.steps ids: [ 'base-pre', 'middle-execute', 'middle-validate' ]
PASS
```

Before the fix the same script output `evaluate.steps ids: [ 'base-pre' ]` — middle-layer steps dropped. Full script included in #221.

I've happily left the new Jest tests in place anyway so they run once the `import.meta.url` / ts-jest issue is resolved separately.

## Design notes

Picked shadow semantics (nearest-ancestor-wins) rather than accumulate-across-chain to keep the change minimal and backward-compatible with the documented intent. Happy to retarget if you'd prefer accumulation — that would change the table above so silent middle layers still contribute their `steps` when the child *also* defines them.

## Test plan

- [x] `npm run build` — clean tsc
- [x] Repro script: 3-tier chain, middle defines `evaluate.steps`, child silent — middle steps now surface
- [x] Repro script: 2-tier chain, child defines `evaluate.steps` — child steps still win (shadowing preserved)
- [x] Repro script: child `steps: []` — still shadows ancestor (opt-out preserved)
- [ ] Jest suite — blocked by unrelated pre-existing `import.meta.url` compile error on `main`; new tests added but not executed under ts-jest

🤖 Generated with [Claude Code](https://claude.com/claude-code)