### PR TITLE
chore: bump cli to 1.6.5 and sdk to 2.5.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber-cli",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "FABER CLI - Command-line interface for FABER development toolkit",
   "main": "dist/index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "cli": {
       "name": "@fractary/faber-cli",
-      "version": "1.6.3",
+      "version": "1.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@fractary/core": "*",
@@ -10628,7 +10628,7 @@
     },
     "sdk/js": {
       "name": "@fractary/faber",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@fractary/core": "*",

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fractary/faber",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractary/faber",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@fractary/forge": "^1.1.1",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractary/faber",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "FABER SDK - Development toolkit for AI-assisted workflows",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `@fractary/faber-cli` from 1.6.4 to 1.6.5
- Bumps `@fractary/faber` SDK from 2.5.3 to 2.5.4
- Updates package-lock.json files accordingly